### PR TITLE
Setting default-directory for spec mode

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -356,7 +356,10 @@
   (if rspec-use-rvm
       (rvm-activate-corresponding-ruby))
   (rspec-register-verify-redo (cons 'rspec-run opts))
-  (compile (mapconcat 'identity (list (rspec-runner) (rspec-spec-directory (rspec-project-root)) (rspec-runner-options opts)) " "))
+  (let ((curdir (file-name-as-directory default-directory)))
+    (setq default-directory (rspec-project-root))
+    (compile (mapconcat 'identity (list (rspec-runner) (rspec-spec-directory (rspec-project-root)) (rspec-runner-options opts)) " "))
+    (setq default-directory curdir))
   (end-of-buffer-other-window 0))
 
 (defun rspec-run-single-file (spec-file &rest opts)
@@ -364,7 +367,10 @@
   (if rspec-use-rvm
       (rvm-activate-corresponding-ruby))
   (rspec-register-verify-redo (cons 'rspec-run-single-file (cons spec-file opts)))
-  (compile (mapconcat 'identity (list (rspec-runner) (rspec-runner-target spec-file) (rspec-runner-options opts)) " "))
+  (let ((curdir (file-name-as-directory default-directory)))
+    (setq default-directory (rspec-project-root))
+    (compile (mapconcat 'identity (list (rspec-runner) (rspec-runner-target spec-file) (rspec-runner-options opts)) " "))
+    (setq default-directory curdir))
   (end-of-buffer-other-window 0))
 
 (defun rspec-project-root (&optional directory)


### PR DESCRIPTION
Hello. I was having an issue with the default-directory not being set to rspec-project-root. I was only having this issue in spec mode (not rake). I've fixed this issue in this commit. Please pull for review. 

This was an issue I had opened and closed: https://github.com/pezra/rspec-mode/issues/closed#issue/10
