### PR TITLE
Trivial implementation of .rspec file support.

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -310,15 +310,21 @@
 
 (defun rspec-core-options (&optional default-options)
   "Returns string of options that instructs spec to use spec.opts file if it exists, or sensible defaults otherwise"
-  (if (file-readable-p (rspec-spec-opts-file))
-      (concat "--options " (rspec-spec-opts-file))
-    (if default-options
-        default-options
-        (concat "--format specdoc " "--reverse"))))
+  (if (file-readable-p (rspec-dotrspec-file))
+      nil
+    (if (file-readable-p (rspec-spec-opts-file))
+	(concat "--options " (rspec-spec-opts-file))
+      (if default-options
+	  default-options
+        (concat "--format specdoc " "--reverse")))))
 
 (defun rspec-spec-opts-file ()
   "Returns filename of spec opts file (usually spec/spec.opts)"
   (concat (rspec-spec-directory (rspec-project-root)) "/spec.opts"))
+
+(defun rspec-dotrspec-file ()
+  "Returns filename of the .rspec file (usually .rspec)"
+  (concat (rspec-project-root) ".rspec"))
 
 (defun rspec-runner ()
   "Returns command line to run rspec"


### PR DESCRIPTION
Hi

I'm not having much luck using your copy of rspec against rspec 2.0 as it fails fatally when provided the --reverse option. As a super-trivial work around I put in support for looking for a .rspec file in the directory root. If the .rspec file is there, it doesn't include any options at all, relying on rspec to find it's config from the .rspec file.

I'm using it against Aquamacs with good success. Please give it a look and consider it as a step toward RSpec 2.0 compatibility.

-Alex
