### PR TITLE
pass a test

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -306,7 +306,7 @@
 
 (defun rspec-spec-file-p (a-file-name)
   "Returns true if the specified file is a spec"
-  (string-match "\\(_\\|-\\)spec\\.rb$" a-file-name))
+  (numberp (string-match "\\(_\\|-\\)spec\\.rb$" a-file-name)))
 
 (defun rspec-core-options (&optional default-options)
   "Returns string of options that instructs spec to use spec.opts file if it exists, or sensible defaults otherwise"


### PR DESCRIPTION
This test code expect t, but got 12.
If you expect any non-nil value, you should use 'non-nil'.
