### PR TITLE
changes to compilation-error-regexp-alist

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -471,9 +471,8 @@ as the value of the symbol, and the hook as the function definition."
      old)))
 
 
-(add-to-list 'compilation-error-regexp-alist-alist 
-	     '(rspec "\\([0-9A-Za-z_./\:-]+\\.rb\\):\\([0-9]+\\)" 1 2))
-(add-to-list 'compilation-error-regexp-alist 'rspec)
+(add-to-list 'compilation-error-regexp-alist '("\\([0-9A-Za-z_./\:-]+\\.rb\\):\\([0-9]+\\)" 1 2))
+  
 
 (condition-case nil
     (progn


### PR DESCRIPTION
This fixes Issue #17 on my installation of emacs (23.2.1).

However, I don't know whether there's an error in the original setup or if I'm breaking another flavour of emacs.  The code that was there doesn't look like it's the XEmacs version (http://www.emacswiki.org/emacs/CreatingYourOwnCompileErrorRegexp).
