### PR TITLE
variable to turn of bundler use if necessary

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -123,6 +123,10 @@
   :type 'boolean
   :group 'rspec-mode)
 
+(defcustom rspec-use-bundler-when-possible t
+  "t when rspec should be run with 'bundle exec' whenever possible. (Gemfile present)"
+  :type 'boolean
+  :group 'rspec-mode)
 
 ;;;###autoload
 (define-minor-mode rspec-mode
@@ -318,7 +322,8 @@
       (rspec-default-options))))
 
 (defun rspec-bundle-p ()
-  (file-readable-p (concat (rspec-project-root) "Gemfile")))
+  (and rspec-use-bundler-when-possible
+       (file-readable-p (concat (rspec-project-root) "Gemfile"))))
 
 (defun rspec2-p ()
   (or (string-match "rspec" rspec-spec-command)


### PR DESCRIPTION
In my project loading bundler takes some time (more than a second actually). Since I want to have a fast spec-runtime I normally run my specs directly with the "rspec" command.

I added a Variable to turn of the "bundle exec" part in rspec-mode even if the project is managed by bundler. I activated it by default, so It should not change the current behavior of rspec-mode.

Cheers
-- Yves
