### PR TITLE
Add @ char to rspec's compilation-error-regexp-alist-alist

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -498,7 +498,7 @@ as the value of the symbol, and the hook as the function definition."
 (add-hook 'compilation-mode-hook
           (lambda ()
             (add-to-list 'compilation-error-regexp-alist-alist
-                         '(rspec "\\([0-9A-Za-z_./\:-]+\\.rb\\):\\([0-9]+\\)" 1 2))
+                         '(rspec "\\([0-9A-Za-z@_./\:-]+\\.rb\\):\\([0-9]+\\)" 1 2))
             (add-to-list 'compilation-error-regexp-alist 'rspec)))
 
 (condition-case nil


### PR DESCRIPTION
Before when someone was using rvm gemsets he couldn't jump to file because of `@` char in the path (e.g. `/Users/asok/.rvm/gems/ruby-1.9.3-p125@mygemset/gems/foo/bar.rb:1` 
