### PR TITLE
rspec-from-project-root should not be a macro

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -179,8 +179,11 @@
   (setq imenu-create-index-function 'imenu-default-create-index-function)
   (setq imenu-generic-expression rspec-imenu-generic-expression))
 
-(add-hook 'rspec-mode-hook 'rspec-set-imenu-generic-expression)
-
+(add-hook 'rspec-mode-hook
+          (lambda ()
+            (rspec-set-imenu-generic-expression)
+            (merge-abbrev-tables rspec-mode-abbrev-table
+                                 local-abbrev-table)))
 ;; Snippets
 (if (require 'snippet nil t)
     (snippet-with-abbrev-table
@@ -462,7 +465,7 @@
 (defun rspec-from-project-root (body-form)
   "Peform body-form from the project root directory"
   (rspec-from-direcory (or (rspec-project-root) default-directory)
-		       body-form))
+                       body-form))
 
 ;; Makes sure that Rspec buffers are given the rspec minor mode by default
 ;;;###autoload


### PR DESCRIPTION
AS metioned in the emacs lisp reference
" When a macro call appears in a Lisp program being compiled, the Lisp compiler calls the macro definition just as the interpreter would, and receives an expansion. But instead of evaluating this expansion, it compiles the expansion as if it had appeared directly in the program. As a result, the compiled code produces the value and side effects intended for the macro, but executes at full compiled speed. This would not work if the macro body computed the value and side effects itself--they would be computed at compile time, which is not useful. "

The macro with a runtime variable would cause some side effect.

and since the macro contains "(or (rspec-project-root) default-directory)",when we compile the rspec-mode,the runtime variables would be assigned and become static. and it would cause the spec run in a wrong root directory.

we need to change the macro to function to fix the issue.

cheers!
