### PR TITLE
Pass filenames at the end of command.

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -423,8 +423,9 @@
       (rvm-activate-corresponding-ruby))
   (rspec-from-project-root
    (let ((compilation-scroll-output t))
-     (compile (mapconcat 'identity `(,(rspec-runner) ,a-file-or-dir
-                                     ,(rspec-runner-options opts)) " ")
+     (compile (mapconcat 'identity `(,(rspec-runner)
+                                     ,(rspec-runner-options opts)
+                                     ,a-file-or-dir) " ")
               'rspec-compilation-mode))))
 
 (defvar rspec-compilation-mode-font-lock-keywords


### PR DESCRIPTION
It turns out that with newer zeus and rspec the order of the args is important. That is with options after filenames zeus fails to run specs.
Maybe it would be better if I would create an issue in the zeus repository. But according to `rspec --help` options should go before filenames.
