### PR TITLE
Apply ansi color only on newly added region of the buffer.

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -503,7 +503,7 @@ as the value of the symbol, and the hook as the function definition."
       (require 'ansi-color)
       (defun rspec-colorize-compilation-buffer ()
         (toggle-read-only)
-        (ansi-color-apply-on-region (point-min) (point-max))
+        (ansi-color-apply-on-region compilation-filter-start (point))
         (toggle-read-only))
       (add-hook 'compilation-filter-hook 'rspec-colorize-compilation-buffer))
     (error nil))


### PR DESCRIPTION
From docs about `compilation-filter-hook`:

> Hook run after `compilation-filter` has inserted a string into the buffer.
> is called with the variable `compilation-filter-start` bound
> to the position of the start of the inserted text, and point at
> its end.

I have no numbers to back it up. But subjectively output on my machine appears a bit faster.
