### PR TITLE
Added cl to standard requirement set. (needed for car-> first alias)

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -93,6 +93,7 @@
 
 ;;; Code:
 (require 'ruby-mode)
+(require 'cl)
 
 (defconst rspec-mode-abbrev-table (make-abbrev-table))
 


### PR DESCRIPTION
Minor fix to ensure rspec-mode works in a basic emacs environment.
