### PR TITLE
Define macros before they're used. 

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -176,6 +176,16 @@
   '(("Examples"  "^\\( *\\(it\\|describe\\|context\\) +.+\\)"          1))
   "The imenu regex to parse an outline of the rspec file")
 
+(defmacro rspec-from-directory (directory body-form)
+  "Peform body-form from the specified directory"
+  `(let ((default-directory ,directory))
+     ,body-form))
+
+(defmacro rspec-from-project-root (body-form)
+  "Peform body-form from the project root directory"
+  `(rspec-from-directory (or (rspec-project-root) default-directory)
+                         ,body-form))
+
 (defun rspec-set-imenu-generic-expression ()
   (make-local-variable 'imenu-generic-expression)
   (make-local-variable 'imenu-create-index-function)
@@ -458,15 +468,6 @@
           ((file-exists-p (expand-file-name "Gemfile" directory)) directory)
           (t (rspec-project-root (file-name-directory (directory-file-name directory)))))))
 
-(defmacro rspec-from-directory (directory body-form)
-  "Peform body-form from the specified directory"
-  `(let ((default-directory ,directory))
-     ,body-form))
-
-(defmacro rspec-from-project-root (body-form)
-  "Peform body-form from the project root directory"
-  `(rspec-from-directory (or (rspec-project-root) default-directory)
-                        ,body-form))
 
 ;; Make sure that Rspec buffers are given the rspec minor mode by default
 ;;;###autoload


### PR DESCRIPTION
Hi Peter. 

Since upgrading to Emacs 24.3.1 OSX (installed via latest homebrew formula),  I've been getting the error mentioned in issue https://github.com/pezra/rspec-mode/issues/43. 

I was able to get rid of the issue by re-evaulating rspec-compile after the package is loaded and ultimately correct the issue by moving the macro definitions in rspec-mode.el so they are defined before use.

It may have something to do with macros and byte compilation as described here: http://www.chemie.fu-berlin.de/chemnet/use/info/elisp/elisp_13.html, but I'm not very good with elisp so I can't say for sure. 

I'd really like to know definitively why this is happening and different than 24.2.1 but I can't seem to figure out exactly why the behavior is different. I just know I have this symptom and this fixes it so I figured I'd submit a pull request. 
