### PR TITLE
Add spring support

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -143,6 +143,11 @@
   :type 'boolean
   :group 'rspec-mode)
 
+(defcustom rspec-use-spring-when-possible t
+  "t when rspec should be run with 'spring' whenever possible. (tmp/spring/spring.pid present)"
+  :type 'boolean
+  :group 'rspec-mode)
+
 (defcustom rspec-use-opts-file-when-available t
   "t if rspec should use .rspec/spec.opts"
   :type 'boolean
@@ -357,6 +362,10 @@
   (and rspec-use-zeus-when-possible
        (file-exists-p (concat (rspec-project-root) ".zeus.sock"))))
 
+(defun rspec-spring-p ()
+  (and rspec-use-spring-when-possible
+       (file-exists-p (concat (rspec-project-root) "tmp/spring/spring.pid"))))
+
 (defun rspec2-p ()
   (or (string-match "rspec" rspec-spec-command)
       (file-readable-p (concat (rspec-project-root) ".rspec"))))
@@ -375,10 +384,13 @@
 (defun rspec-runner ()
   "Returns command line to run rspec"
   (let ((bundle-command (if (rspec-bundle-p) "bundle exec " ""))
-        (zeus-command (if (rspec-zeus-p) "zeus " "")))
-    (concat bundle-command zeus-command (if rspec-use-rake-flag
-                                            (concat rspec-rake-command " spec")
-                                          rspec-spec-command))))
+        (zeus-command (if (rspec-zeus-p) "zeus " nil))
+        (spring-command (if (rspec-spring-p) "spring " nil)))
+    (concat bundle-command
+            (or zeus-command spring-command "")
+            (if rspec-use-rake-flag
+                (concat rspec-rake-command " spec")
+              rspec-spec-command))))
 
 (defun rspec-runner-options (&optional opts)
   "Returns string of options for command line"


### PR DESCRIPTION
This patch is different from hirocaster's in
(https://github.com/hirocaster/rspec-mode/commit/1a06e50f1f6c940e6d998253c0ba81add5aad738)
- Symmetric with other options (checking file existence)
- Use spring if possible
- Do not prefix both spring and zeus even if both are working
