### PR TITLE
yas-extra-modes is not a function

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -194,7 +194,7 @@ Not used when running specs using Zeus or Spring."
         (rspec-set-imenu-generic-expression)
         (when (boundp 'yas-extra-modes)
           (make-local-variable 'yas-extra-modes)
-          (setq yas-extra-modes (cons 'rspec-mode (yas-extra-modes)))))
+          (add-to-list 'yas-extra-modes 'rspec-mode)))
     (setq imenu-create-index-function 'ruby-imenu-create-index)
     (setq imenu-generic-expression nil)
     (when (boundp 'yas-extra-modes)


### PR DESCRIPTION
In addition, whether or not yas-extra-modes is nil, a single element, or
an existing list, this will correctly add rspec-mode to it, and convert
it to a list allowing the subsequent removal on disabling the mode to
always succeed.
