### PR TITLE
Fix yas-snippet-dirs to append rspec-snippet-dir

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -235,7 +235,7 @@ Not used when running specs using Zeus or Spring."
 (defun rspec-install-snippets ()
   "Add `rspec-snippets-dir' to `yas-snippet-dirs' and load snippets from it."
   (require 'yasnippet)
-  (setq yas-snippet-dirs (cons rspec-snippets-dir (yas-snippet-dirs)))
+  (add-to-list 'yas-snippet-dirs rspec-snippets-dir t)
   (yas-load-directory rspec-snippets-dir))
 
 (defun rspec-class-from-file-name ()


### PR DESCRIPTION
The first directory in yas-snippets-dirs is used as the default location
to save a new snippet to. The default documentation for running
rspec-install-snippets will add rspec-snippets-dir to the list very
late. In order to be respectful to the users defaults we should append
rspec-snippet-dir to the list instead of placing it at the beginning.
