### PR TITLE
Prefer using zeus spec over zeus rake spec

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -494,7 +494,7 @@ file if it exists, or sensible defaults otherwise"
   (and rspec-use-rake-when-possible
        ;; Looks inefficient, but the calculation of the root is quite
        ;; fast. Unless this is used over TRAMP, I suppose.
-       (not (rspec-spring-p))
+       (not (or (rspec-spring-p) (rspec-zeus-p)))
        (file-exists-p (concat (rspec-project-root) "Rakefile"))))
 
 (defun rspec-spring-p ()


### PR DESCRIPTION
Zeus appears to keep rake in the development environment, unlike zeus
spec which runs in the test environment.
