### PR TITLE
Capybara screenshot links

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -620,7 +620,7 @@ TARGET can be a file, a directory, or a list of such."
                  (rspec-capybara-screenshot
                   "Screenshot: \\([0-9A-Za-z@_./\:-]+\\.png\\)" 1 nil nil 0 1)
                  (rspec
-                  "rspec +\\([0-9A-Za-z@_./\:-]+\\.rb\\):\\([0-9]+\\)" 1 2))
+                  "rspec +\\([0-9A-Za-z@_./\:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 2 1))
                compilation-error-regexp-alist-alist))
   (setq font-lock-defaults '(rspec-compilation-mode-font-lock-keywords t))
   (add-hook 'compilation-filter-hook 'rspec-colorize-compilation-buffer nil t))


### PR DESCRIPTION
Adds support for linking to screenshots generated by [capybara-screenshot](https://github.com/mattheworiordan/capybara-screenshot), and limits the hyperlink to only the filename on the final rspec lines.
