### PR TITLE
Favor single quotes in snippets to comply with ruby style guide

### DIFF
--- a/snippets/rspec-mode/cont
+++ b/snippets/rspec-mode/cont
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
-# name: context "modifier" do ... end
+# name: context 'modifier' do ... end
 # --
-context "${1:modifier}" do
+context '${1:modifier}' do
   $0
 end

--- a/snippets/rspec-mode/desc
+++ b/snippets/rspec-mode/desc
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
 # name: describe Class do ... end
-# expand-env: ((top-level (rspec-top-level-desc-p)) (maybe-quote (unless top-level "\"")))
+# expand-env: ((top-level (rspec-top-level-desc-p)) (maybe-quote (unless top-level "\'")))
 # --
 describe `maybe-quote`${1:`(and top-level (rspec-class-from-file-name))`}`maybe-quote` do
   $0

--- a/snippets/rspec-mode/feat
+++ b/snippets/rspec-mode/feat
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
-# name: feature "description" do ... end
+# name: feature 'description' do ... end
 # --
-feature "${1:description}" do
+feature '${1:description}' do
   $0
 end

--- a/snippets/rspec-mode/featm
+++ b/snippets/rspec-mode/featm
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
-# name: feature "description", "modifier" do ... end
+# name: feature 'description', 'modifier' do ... end
 # --
-feature "${1:description}", "${2:modifier}" do
+feature '${1:description}', '${2:modifier}' do
   $0
 end

--- a/snippets/rspec-mode/it
+++ b/snippets/rspec-mode/it
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
-# name: it "does something" do ... end
+# name: it 'does something' do ... end
 # --
-it "${1:does something}" do
+it '${1:does something}' do
   $0
 end

--- a/snippets/rspec-mode/scn
+++ b/snippets/rspec-mode/scn
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
 # name: scenario "does something" do ... end
 # --
-scenario "${1:does something}" do
+scenario '${1:does something}' do
   $0
 end


### PR DESCRIPTION
I have changed the snippets to use single instead of double quotes, as the [ruby style guide](https://github.com/bbatsov/ruby-style-guide#strings) suggests
