### PR TITLE
Added keymaps to help strings of rspec-mode, et. al

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -235,7 +235,7 @@ there's an `include FactoryGirl::Syntax::Methods' statement in spec_helper."
 (define-minor-mode rspec-dired-mode
   "Minor mode for Dired buffers with spec files
 
-\\{rspec-dired-mode-map"
+\\{rspec-dired-mode-map}"
   :lighter "" :keymap `((,rspec-key-command-prefix . rspec-dired-mode-keymap)))
 
 (defconst rspec-imenu-generic-expression


### PR DESCRIPTION
I don't use ruby and rspec-mode much and I can't remember the keymaps so I added them to the documentation strings.
You might not like my changes.  There is some magic I don't understand with \{foo-mode-map}.  The keymap, it appears, must be named foo-mode-keymap for the magic to work.  \{foo-mode-map} gives me the complete path to each function whereas \{foo-mode-keymap} only gives me the last key stroke.
In any case, to make the magic work, I had to change rspec-mode-verifiable-keymap to rspec-verifiable-mode-keymap because the mode is rspec-verifiable-mode -- not rspec-mode-verifiable.
