### PR TITLE
Allow methods terminated in '?' when searching specs

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -390,14 +390,14 @@ target, otherwise the spec."
                       (save-excursion
                         (end-of-line)
                         (or
-                         (re-search-backward "\\(?:describe\\|context\\) ['\"][#\\.]\\([_a-zA-Z\\?\\!]*\\)['\"] do" nil t)
+                         (re-search-backward "\\(?:describe\\|context\\) ['\"][#\\.]\\([a-zA-Z_?!]*\\)['\"] do" nil t)
                          (error "No method spec before point"))
                         (match-string 1)))
        (get-method-name ()
                         (save-excursion
                           (end-of-line)
                           (or
-                           (re-search-backward "def \\(?:self\\)?\\(.?[_a-zA-Z\\?\\!]+\\)" nil t)
+                           (re-search-backward "def \\(?:self\\)?\\(.?[a-zA-Z_?!]+\\)" nil t)
                            (error "No method definition before point"))
                           (match-string 1))))
     (let* ((spec-p (rspec-buffer-is-spec-p))


### PR DESCRIPTION
I have found a bug where `rspec--toggle-spec-and-target-find-method`
would not work if the `method` name ended with '?' as in ruby
predicates.

This commit address this issue by using the `regexp-quote` before
formatting the `target-regexp` used for finding the method/spec
definition in the target/spec file.
