### PR TITLE
Fix bug in `rspec--include-fg-syntax-methods-p`

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -202,7 +202,7 @@ there's an `include FactoryGirl::Syntax::Methods' statement in spec_helper."
           (const concise)
           (const nil))
   :group 'rspec-mode)
-  
+
 (defcustom rspec-auto-scroll t
   "Auto scroll the output"
   :type 'boolean
@@ -733,7 +733,7 @@ or a cons (FILE . LINE), to run one example."
   (cl-case rspec-snippets-fg-syntax
     (full nil)
     (concise t)
-    (nil
+    (t
      (with-temp-buffer
        (insert-file-contents
         (concat (rspec-project-root) "spec/spec_helper.rb"))


### PR DESCRIPTION
When called with `nil`, `cl-case` always return `nil`, even if there is an
explicit `nil` case. (see [doc](https://www.gnu.org/software/emacs/manual/html_node/cl/Conditionals.html))

For example,

```elisp
(setq myvar nil)
(cl-case myvar
  (one 1)
  (two 2)
  (nil 3)) # => nil, and not 3!
```

That is probably not what was meant by the author of
`rspec--include-fg-syntax-methods-p`. This commit changes the `nil`
option in the custom variable `rspec-snippets-fg-syntax` to the symbol`check`.

ps: Happy new year!