### PR TITLE
Replace compilation-error-regexp alists rather than appending to them

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -683,16 +683,12 @@ or a cons (FILE . LINE), to run one example."
 (define-derived-mode rspec-compilation-mode compilation-mode "RSpec Compilation"
   "Compilation mode for RSpec output."
   (set (make-local-variable 'compilation-error-regexp-alist)
-       (append '(rspec rspec-capybara-html rspec-capybara-screenshot)
-               compilation-error-regexp-alist))
+       '(rspec rspec-capybara-html rspec-capybara-screenshot))
   (set (make-local-variable 'compilation-error-regexp-alist-alist)
-       (append '((rspec-capybara-html
-                  "Saved file \\([0-9A-Za-z@_./\:-]+\\.html\\)" 1 nil nil 0 1)
-                 (rspec-capybara-screenshot
-                  "Screenshot: \\([0-9A-Za-z@_./\:-]+\\.png\\)" 1 nil nil 0 1)
-                 (rspec
-                  "rspec +\\([0-9A-Za-z@_./\:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 2 1))
-               compilation-error-regexp-alist-alist))
+       '((rspec-capybara-html "Saved file \\([0-9A-Za-z@_./\:-]+\\.html\\)" 1 nil nil 0 1)
+         (rspec-capybara-screenshot "Screenshot: \\([0-9A-Za-z@_./\:-]+\\.png\\)" 1 nil nil 0 1)
+         (rspec "rspec +\\([0-9A-Za-z@_./\:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 2 1))
+       )
   (setq font-lock-defaults '(rspec-compilation-mode-font-lock-keywords t))
   (add-hook 'compilation-filter-hook 'rspec-colorize-compilation-buffer nil t)
   (add-hook 'compilation-finish-functions 'rspec-handle-error nil t))

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -687,7 +687,7 @@ or a cons (FILE . LINE), to run one example."
   (set (make-local-variable 'compilation-error-regexp-alist-alist)
        '((rspec-capybara-html "Saved file \\([0-9A-Za-z@_./\:-]+\\.html\\)" 1 nil nil 0 1)
          (rspec-capybara-screenshot "Screenshot: \\([0-9A-Za-z@_./\:-]+\\.png\\)" 1 nil nil 0 1)
-         (rspec "rspec +\\([0-9A-Za-z@_./\:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 2 1))
+         (rspec "^rspec +\\([0-9A-Za-z@_./\:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 2 1))
        )
   (setq font-lock-defaults '(rspec-compilation-mode-font-lock-keywords t))
   (add-hook 'compilation-filter-hook 'rspec-colorize-compilation-buffer nil t)

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -680,15 +680,17 @@ or a cons (FILE . LINE), to run one example."
     ("^[0-9]+ examples?, \\([0-9]+ failures?\\)"
      (1 compilation-error-face))))
 
+(defvar rspec--compilation-error-regexp-alist-alist
+      '((rspec-capybara-html "Saved file \\([0-9A-Za-z@_./\:-]+\\.html\\)" 1 nil nil 0 1)
+        (rspec-capybara-screenshot "Screenshot: \\([0-9A-Za-z@_./\:-]+\\.png\\)" 1 nil nil 0 1)
+        (rspec "^\\(?:rspec\\|\\(?: +#\\)\\) \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 2 1)))
+
 (define-derived-mode rspec-compilation-mode compilation-mode "RSpec Compilation"
   "Compilation mode for RSpec output."
-  (set (make-local-variable 'compilation-error-regexp-alist)
-       '(rspec rspec-capybara-html rspec-capybara-screenshot))
   (set (make-local-variable 'compilation-error-regexp-alist-alist)
-       '((rspec-capybara-html "Saved file \\([0-9A-Za-z@_./\:-]+\\.html\\)" 1 nil nil 0 1)
-         (rspec-capybara-screenshot "Screenshot: \\([0-9A-Za-z@_./\:-]+\\.png\\)" 1 nil nil 0 1)
-         (rspec "\s*\\(?:^rspec\\|#\\) +\\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 2 1))
-       )
+       rspec--compilation-error-regexp-alist-alist)
+  (set (make-local-variable 'compilation-error-regexp-alist)
+       (mapcar 'car rspec--compilation-error-regexp-alist-alist))
   (setq font-lock-defaults '(rspec-compilation-mode-font-lock-keywords t))
   (add-hook 'compilation-filter-hook 'rspec-colorize-compilation-buffer nil t)
   (add-hook 'compilation-finish-functions 'rspec-handle-error nil t))

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -687,7 +687,7 @@ or a cons (FILE . LINE), to run one example."
   (set (make-local-variable 'compilation-error-regexp-alist-alist)
        '((rspec-capybara-html "Saved file \\([0-9A-Za-z@_./\:-]+\\.html\\)" 1 nil nil 0 1)
          (rspec-capybara-screenshot "Screenshot: \\([0-9A-Za-z@_./\:-]+\\.png\\)" 1 nil nil 0 1)
-         (rspec "^rspec +\\([0-9A-Za-z@_./\:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 2 1))
+         (rspec "\s*\\(?:^rspec\\|#\\) +\\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 2 1))
        )
   (setq font-lock-defaults '(rspec-compilation-mode-font-lock-keywords t))
   (add-hook 'compilation-filter-hook 'rspec-colorize-compilation-buffer nil t)

--- a/test/rspec-mode-test.el
+++ b/test/rspec-mode-test.el
@@ -1,0 +1,23 @@
+;; -*- lexical-binding: t; -*-
+(require 'rspec-mode)
+
+;;; Test regexp matches in compilation buffer
+(defun rspec--test-re ()
+  (nth 1 (assq 'rspec rspec--compilation-error-regexp-alist-alist)))
+
+(ert-deftest rspec--test-regexp-backtrace ()
+  "matches backtrace"
+  (let ((example "    # ./app/controllers/posts_controller.rb:7:in `create'"))
+    (should (string-match (rspec--test-re) example))))
+
+(ert-deftest rspec--test-regexp-summary ()
+  "matches rspec summary lines"
+  (let
+      ((example "rspec ./spec/foo/bar_spec.rb:21 # description"))
+    (should (string-match (rspec--test-re) example))))
+
+(ert-deftest rspec--test-regexp-deprecation ()
+  "does not match deprecation warnings"
+  (let
+      ((example "/path/to/file.rb:112: warning: duplicated key at line 132 ignored: :foobar"))
+    (should-not (string-match (rspec--test-re) example))))


### PR DESCRIPTION
Current `compilation-errors-regexp-alist*` is great, however it is appended to the original list, making matches too wide. After catching rspec errors, it goes further and runs other matchers which find incorrect lines. For example,
```ruby
/home/ineu/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/htmlcompressor-0.1.2/lib/htmlcompressor/compressor.rb:112: warning: duplicated key at line 132 ignored: :javascript_compressor
/home/ineu/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/htmlcompressor-0.1.2/lib/htmlcompressor/compressor.rb:113: warning: duplicated key at line 133 ignored: :css_compressor
```
It marks these lines as errors as well, though they are really deprecations.
This PR completely replaces predefined alist.