### PR TITLE
Pending specs should not be marked as errors

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -680,7 +680,8 @@ or a cons (FILE . LINE), to run one example."
 (defvar rspec--compilation-error-regexp-alist-alist
       '((rspec-capybara-html "Saved file \\([0-9A-Za-z@_./\:-]+\\.html\\)" 1 nil nil 0 1)
         (rspec-capybara-screenshot "Screenshot: \\([0-9A-Za-z@_./\:-]+\\.png\\)" 1 nil nil 0 1)
-        (rspec "^\\(?:rspec\\|\\(?: +#\\)\\) \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 2 1)))
+        (rspec "^ +# \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\):in" 1 2 nil 2 1)
+        (rspec-summary "^rspec \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 2 1)))
 
 (define-derived-mode rspec-compilation-mode compilation-mode "RSpec Compilation"
   "Compilation mode for RSpec output."

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -681,6 +681,7 @@ or a cons (FILE . LINE), to run one example."
       '((rspec-capybara-html "Saved file \\([0-9A-Za-z@_./\:-]+\\.html\\)" 1 nil nil 0 1)
         (rspec-capybara-screenshot "Screenshot: \\([0-9A-Za-z@_./\:-]+\\.png\\)" 1 nil nil 0 1)
         (rspec "^ +# \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\):in" 1 2 nil 2 1)
+        (rspec-deprecations "^ +# \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 0 1)
         (rspec-summary "^rspec \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 2 1)))
 
 (define-derived-mode rspec-compilation-mode compilation-mode "RSpec Compilation"

--- a/test/rspec-mode-test.el
+++ b/test/rspec-mode-test.el
@@ -2,22 +2,21 @@
 (require 'rspec-mode)
 
 ;;; Test regexp matches in compilation buffer
-(defun rspec--test-re ()
-  (nth 1 (assq 'rspec rspec--compilation-error-regexp-alist-alist)))
+(defun rspec--test-compilation-match-p (example)
+  (some 'identity (mapcar (lambda (n) (string-match (nth 1 n) example)) rspec--compilation-error-regexp-alist-alist)))
 
 (ert-deftest rspec--test-regexp-backtrace ()
   "matches backtrace"
-  (let ((example "    # ./app/controllers/posts_controller.rb:7:in `create'"))
-    (should (string-match (rspec--test-re) example))))
+  (should (rspec--test-compilation-match-p "    # ./app/controllers/posts_controller.rb:7:in `create'")))
 
 (ert-deftest rspec--test-regexp-summary ()
   "matches rspec summary lines"
-  (let
-      ((example "rspec ./spec/foo/bar_spec.rb:21 # description"))
-    (should (string-match (rspec--test-re) example))))
+  (should (rspec--test-compilation-match-p "rspec ./spec/foo/bar_spec.rb:21 # description")))
 
 (ert-deftest rspec--test-regexp-deprecation ()
   "does not match deprecation warnings"
-  (let
-      ((example "/path/to/file.rb:112: warning: duplicated key at line 132 ignored: :foobar"))
-    (should-not (string-match (rspec--test-re) example))))
+  (should-not (rspec--test-compilation-match-p "/path/to/file.rb:112: warning: duplicated key at line 132 ignored: :foobar")))
+
+(ert-deftest rspec--test-regexp-pending ()
+  "does not match pending specs"
+  (should-not (rspec--test-compilation-match-p "    # ./spec/controllers/pages_controller_spec.rb:65")))


### PR DESCRIPTION
Pending specs are no longer displayed as error, neither they are picked by next-error. Fixes #1.