### PR TITLE
Recognize describe blocks with metadata on find-{example,method}

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -407,7 +407,7 @@ target, otherwise the spec."
                       (save-excursion
                         (end-of-line)
                         (or
-                         (re-search-backward "\\(?:describe\\|context\\) ['\"][#\\.]\\([a-zA-Z_?!]*\\)['\"] do" nil t)
+                         (re-search-backward "\\(?:describe\\|context\\)\s*(?[\s\n]*['\"][#\\.]\\([a-zA-Z_?!]*\\)['\"].*[\n\s)]* ?do" nil t)
                          (error "No method spec before point"))
                         (match-string 1)))
        (get-method-name ()
@@ -420,7 +420,7 @@ target, otherwise the spec."
     (let* ((spec-p (rspec-buffer-is-spec-p))
            (target-regexp (if spec-p
                               (format "def \\(self\\)?\\.?%s" (regexp-quote (get-spec-name)))
-                            (format "\\(describe\\|context\\) ['\"]#?%s['\"]" (regexp-quote (get-method-name))))))
+                            (format "\\(describe\\|context\\)[\s(\n]+['\"]#?%s['\"]" (regexp-quote (get-method-name))))))
       (funcall toggle-function)
       (if (string-match-p target-regexp (buffer-string))
           (progn


### PR DESCRIPTION
This commit enhances the regexps used to jump between method and its
describe block, allowing the describe blocks to contain new lines,
parenthesis and extra metadata.

rspec--togle-spec-and-target-find-method will now recognize describe
blocks of the form:

    describe('#methodz') do

    describe '#methodx', :vcr, cassette: 'methodx' do

    describe('#methody', :vcr, cassette: 'methody') do

    describe(
      '#post_bundlez', :vcr, cassette: 'post_bundlez'
    ) do