### PR TITLE
Add `rspec-verify-method`

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -406,9 +406,9 @@ target, otherwise the spec."
   "Just like rspec-verify-single but tries to find examples for
 method given the current point."
   (interactive)
-  (when (rspec-toggle-spec-and-target-find-example)
-    (rspec-verify-single))
-  (rspec-toggle-spec-and-target))
+  (save-window-excursion
+    (when (rspec-toggle-spec-and-target-find-example)
+      (rspec-verify-single))))
 
 (defun rspec--toggle-spec-and-target-find-method (toggle-function)
   (cl-labels

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -121,6 +121,7 @@
 (define-key rspec-verifiable-mode-keymap (kbd "r") 'rspec-rerun)
 (define-key rspec-verifiable-mode-keymap (kbd "m") 'rspec-verify-matching)
 (define-key rspec-verifiable-mode-keymap (kbd "c") 'rspec-verify-continue)
+(define-key rspec-verifiable-mode-keymap (kbd "s") 'rspec-verify-method)
 
 (set-keymap-parent rspec-mode-keymap rspec-verifiable-mode-keymap)
 
@@ -401,6 +402,14 @@ target, otherwise the spec."
   (interactive)
   (find-file (rspec-spec-or-target)))
 
+(defun rspec-verify-method ()
+  "Just like rspec-verify-single but tries to find examples for
+method given the current point."
+  (interactive)
+  (when (rspec-toggle-spec-and-target-find-example)
+    (rspec-verify-single))
+  (rspec-toggle-spec-and-target))
+
 (defun rspec--toggle-spec-and-target-find-method (toggle-function)
   (cl-labels
       ((get-spec-name ()
@@ -426,7 +435,8 @@ target, otherwise the spec."
           (progn
             (beginning-of-buffer)
             (re-search-forward target-regexp))
-        (message "No matching %s" (if spec-p "method" "spec"))))))
+        (message "No matching %s" (if spec-p "method" "spec"))
+        nil))))
 
 (defun rspec-toggle-spec-and-target-find-example ()
   "Just like rspec-toggle-spec-and-target but tries to toggle between


### PR DESCRIPTION
This commit adds the function `rspec-verify-method` that behaves like
`rspec-verify-single`, but tries to guess which examples to run based on
the method at given point.

The implementation piggy-backs in the functionality provided by
`rspec-toggle-spec-and-target-find-example` for navigation between a
method and it's describe block (and vice-versa)

`rspec-verify-method` is intended to be used only on `code` buffers and
not on `spec` buffers. That's why the keybinding for
`rspec-verify-method` is added in the `rspec-verifiable-mode-keymap`

Ps: I actually wanted to implement `rspec-verify-method` in the following way:

```lisp
(defun rspec-verify-method ()
  "Just like rspec-verify-single but tries to find examples for
method given the current point."
  (interactive)
  (save-excursion
     (rspec-toggle-spec-and-target-find-example)
     (rspec-verify-single)))
```

But for some reason `save-excursion` did not work, and the current buffer was always being changed from `code` to `spec`.

The current implementation looks kinda hacky in my opinion, but it works fine.