### PR TITLE
Look in rails helper for factory girl syntax methods.

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -752,15 +752,19 @@ or a cons (FILE . LINE), to run one example."
           (t (rspec-project-root (file-name-directory (directory-file-name directory)))))))
 
 (defun rspec--include-fg-syntax-methods-p ()
-  "Check whether FactoryGirl::Syntax::Methods is included in spec_helper."
+  "Check whether FactoryGirl::Syntax::Methods is included in rails_helper or spec_helper."
   (cl-case rspec-snippets-fg-syntax
     (full nil)
     (concise t)
     (t
-     (with-temp-buffer
-       (insert-file-contents
-        (concat (rspec-project-root) "spec/spec_helper.rb"))
-       (re-search-forward "include +FactoryGirl::Syntax::Methods" nil t)))))
+     (cl-find-if
+      (lambda (path)
+        (let ((expanded-path (expand-file-name path (rspec-project-root))))
+          (when (file-exists-p expanded-path)
+                (with-temp-buffer
+                  (insert-file-contents expanded-path)
+                  (re-search-forward "include +FactoryGirl::Syntax::Methods" nil t)))))
+      '("spec/rails_helper.rb" "spec/spec_helper.rb")))))
 
 (defun rspec-snippets-fg-method-call (method)
   "Return FactoryGirl method call for METHOD, for use in snippets.

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -761,9 +761,11 @@ or a cons (FILE . LINE), to run one example."
       (lambda (path)
         (let ((expanded-path (expand-file-name path (rspec-project-root))))
           (when (file-exists-p expanded-path)
-                (with-temp-buffer
-                  (insert-file-contents expanded-path)
-                  (re-search-forward "include +FactoryGirl::Syntax::Methods" nil t)))))
+            (with-temp-buffer
+              (insert-file-contents expanded-path)
+              (ruby-mode)
+              (when (re-search-forward "include +FactoryGirl::Syntax::Methods" nil t)
+                (not (nth 4 (syntax-ppss))))))))
       '("spec/rails_helper.rb" "spec/spec_helper.rb")))))
 
 (defun rspec-snippets-fg-method-call (method)


### PR DESCRIPTION
More recent versions of rspec-rails create/recommend creating both a
`rails_helper.rb` and `spec_helper.rb` file, with the intention of
putting rails-specific configuration in the former. Given that a rails
project is set up in this way, including the syntax methods for factory
girl would be expected to go into the rails helper.

This change looks in the rails helper if it exists first before
searching the spec helper for the inclusion of this module.

https://github.com/pezra/rspec-mode/issues/117