### PR TITLE
Fix desc snippet

### DIFF
--- a/snippets/rspec-mode/desc
+++ b/snippets/rspec-mode/desc
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
 # name: describe Class do ... end
-# expand-env: ((top-level (rspec-top-level-desc-p)) (global-dsl (rspec-expose-dsl-globally)) (maybe-quote (unless top-level "\"")))
+# expand-env: ((top-level (rspec-top-level-desc-p)) (global-dsl rspec-expose-dsl-globally) (maybe-quote (unless top-level "\"")))
 # --
 `(and top-level (not global-dsl) "RSpec.")`describe `maybe-quote`${1:`(and top-level (rspec-class-from-file-name))`}`maybe-quote` do
   $0


### PR DESCRIPTION
fixes 

> let*: Symbol's function definition is void: rspec-expose-dsl-globally

 messages on expansion of `desc`.