### PR TITLE
Add keybindings to the README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ Keybinding | Description                                    |
 
 Keybinding | Description                                                    |
 -----------|----------------------------------------------------------------|
- `C-c , v` | Run all specs in the current directory                         |
- `C-c , s` | Run marked specs or spec at point (works with directories too) |
- `C-c , a` | Run the 'spec' rake task for the project of the current file   |
- `C-c , r` | Re-run the last RSpec invocation                               |
+`C-c , v`  | Run all specs in the current directory                         |
+`C-c , s`  | Run marked specs or spec at point (works with directories too) |
+`C-c , a`  | Run the 'spec' rake task for the project of the current file   |
+`C-c , r`  | Re-run the last RSpec invocation                               |
 
 See `rspec-mode.el` for further usage.
 

--- a/README.md
+++ b/README.md
@@ -28,19 +28,19 @@ automatically when `ruby-mode` is started.
 
 ### RSpec Verifiable mode
 
-Keybinding  | Description                                                                                                               |
-------------|---------------------------------------------------------------------------------------------------------------------------|
-`C-c , v`   | Verify the spec file associated with the current buffer                                                                   |
-`C-c , a`   | Run spec for entire project                                                                                               |
-`C-c , t`   | Toggle back and forth between a spec and its target                                                                       |
-`C-c , e`   | Toggle back and forth between a method and its examples in the spec file                                                  |
-`C-c , 4 t` | Find in the other window the spec or the target file                                                                      |
-`C-c , 4 e` | Find in the other window the spec or the target file, and try to navigate to the example or method corresponding to point |
-`C-c , r`   | Re-run the last verification process                                                                                      |
-`C-c , m`   | Run all specs related to the current buffer                                                                               |
-`C-c , c`   | Run the current spec and all after it                                                                                     |
-`C-c , s`   | Verify the example or method defined at point                                                                             |
-`C-c , f`   | Re-run just the failed examples from the last run                                                                         |
+Keybinding  | Description                                                                   |
+------------|-------------------------------------------------------------------------------|
+`C-c , v`   | Verify the spec file associated with the current buffer                       |
+`C-c , a`   | Run spec for entire project                                                   |
+`C-c , t`   | Toggle back and forth between a spec and its target                           |
+`C-c , e`   | Toggle back and forth between a method and its examples in the spec file      |
+`C-c , 4 t` | Find in the other window the spec or the target file                          |
+`C-c , 4 e` | As above, but try to navigate to the example or method corresponding to point |
+`C-c , r`   | Re-run the last verification process                                          |
+`C-c , m`   | Run all specs related to the current buffer                                   |
+`C-c , c`   | Run the current spec and all after it                                         |
+`C-c , s`   | Verify the example or method defined at point                                 |
+`C-c , f`   | Re-run just the failed examples from the last run                             |
 
 ### RSpec mode
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ automatically when `ruby-mode` is started.
 
 ### RSpec Verifiable mode
 
+These keybindings are available in any Ruby source file:
+
 Keybinding  | Description                                                                   |
 ------------|-------------------------------------------------------------------------------|
 `C-c , v`   | Verify the spec file associated with the current buffer                       |
@@ -44,12 +46,16 @@ Keybinding  | Description                                                       
 
 ### RSpec mode
 
+These keybindings are available in Ruby spec files:
+
 Keybinding | Description                                    |
 -----------|------------------------------------------------|
 `C-c , s`  | Run the specified example at point             |
 `C-c , d`  | Toggle the pendingness of the example at point |
 
 ### RSpec Dired mode
+
+These keybindings are available in Dired buffers:
 
 Keybinding | Description                                                    |
 -----------|----------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -26,31 +26,37 @@ may already have set up.)
 If `rspec-mode` is installed properly, it will be started
 automatically when `ruby-mode` is started.
 
-Command                                                             | Description                                                                                                               | RSpec Verifiable mode binding
-------------------------------------------------------------------- |---------------------------------------------------------------------------------------------------------------------------|------------------------------
-<kbd>M-x rspec-verify</kbd>                                         | Verify the spec file associated with the current buffer                                                                   | `C-c , v`
-<kbd>M-x rspec-verify-all</kbd>                                     | Run spec for entire project                                                                                               | `C-c , a`
-<kbd>M-x rspec-toggle-spec-and-target</kbd>                         | Toggle back and forth between a spec and its target                                                                       | `C-c , t`
-<kbd>M-x rspec-toggle-spec-and-target-find-example</kbd>            | Toggle back and forth between a method and its examples in the spec file                                                  | `C-c , e`
-<kbd>M-x rspec-find-spec-or-target-other-window</kbd>               | Find in the other window the spec or the target file                                                                      | `C-c , 4 t`
-<kbd>M-x rspec-find-spec-or-target-find-example-other-window</kbd>  | Find in the other window the spec or the target file, and try to navigate to the example or method corresponding to point | `C-c , 4 e`
-<kbd>M-x rspec-rerun</kbd>                                          | Re-run the last verification process                                                                                      | `C-c , r`
-<kbd>M-x rspec-verify-matching</kbd>                                | Run all specs related to the current buffer                                                                               | `C-c , m`
-<kbd>M-x rspec-verify-continue</kbd>                                | Run the current spec and all after it                                                                                     | `C-c , c`
-<kbd>M-x rspec-verify-method</kbd>                                  | Verify the example or method defined at point                                                                             | `C-c , s`
-<kbd>M-x rspec-run-last-failed</kbd>                                | Re-run just the failed examples from the last run                                                                         | `C-c , f`
+### RSpec Verifiable mode
 
-Command                                         | Description                                    | RSpec mode binding
-------------------------------------------------|------------------------------------------------|-------------------
-<kbd>M-x rspec-verify-single</kbd>              | Run the specified example at point             | `C-c , s`
-<kbd>M-x rspec-toggle-example-pendingness</kbd> | Toggle the pendingness of the example at point | `C-c , d`
+Keybinding  | Description                                                                                                               |
+------------|---------------------------------------------------------------------------------------------------------------------------|
+`C-c , v`   | Verify the spec file associated with the current buffer                                                                   |
+`C-c , a`   | Run spec for entire project                                                                                               |
+`C-c , t`   | Toggle back and forth between a spec and its target                                                                       |
+`C-c , e`   | Toggle back and forth between a method and its examples in the spec file                                                  |
+`C-c , 4 t` | Find in the other window the spec or the target file                                                                      |
+`C-c , 4 e` | Find in the other window the spec or the target file, and try to navigate to the example or method corresponding to point |
+`C-c , r`   | Re-run the last verification process                                                                                      |
+`C-c , m`   | Run all specs related to the current buffer                                                                               |
+`C-c , c`   | Run the current spec and all after it                                                                                     |
+`C-c , s`   | Verify the example or method defined at point                                                                             |
+`C-c , f`   | Re-run just the failed examples from the last run                                                                         |
 
-Command                                  | Description                                                    | RSpec Dired mode binding
------------------------------------------|----------------------------------------------------------------|-------------------------
-<kbd>M-x rspec-dired-verify</kbd>        | Run all specs in the current directory                         | `C-c , v`
-<kbd>M-x rspec-dired-verify-single</kbd> | Run marked specs or spec at point (works with directories too) | `C-c , s`
-<kbd>M-x rspec-verify-all</kbd>          | Run the 'spec' rake task for the project of the current file   | `C-c , a`
-<kbd>M-x rspec-rerun</kbd>               | Re-run the last RSpec invocation                               | `C-c , r`
+### RSpec mode
+
+Keybinding | Description                                    |
+-----------|------------------------------------------------|
+`C-c , s`  | Run the specified example at point             |
+`C-c , d`  | Toggle the pendingness of the example at point |
+
+### RSpec Dired mode
+
+Keybinding | Description                                                    |
+-----------|----------------------------------------------------------------|
+ `C-c , v` | Run all specs in the current directory                         |
+ `C-c , s` | Run marked specs or spec at point (works with directories too) |
+ `C-c , a` | Run the 'spec' rake task for the project of the current file   |
+ `C-c , r` | Re-run the last RSpec invocation                               |
 
 See `rspec-mode.el` for further usage.
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,32 @@ may already have set up.)
 If `rspec-mode` is installed properly, it will be started
 automatically when `ruby-mode` is started.
 
+Command                                                             | Description                                                                                                               | RSpec Verifiable mode binding
+------------------------------------------------------------------- |---------------------------------------------------------------------------------------------------------------------------|------------------------------
+<kbd>M-x rspec-verify</kbd>                                         | Verify the spec file associated with the current buffer                                                                   | `C-c , v`
+<kbd>M-x rspec-verify-all</kbd>                                     | Run spec for entire project                                                                                               | `C-c , a`
+<kbd>M-x rspec-toggle-spec-and-target</kbd>                         | Toggle back and forth between a spec and its target                                                                       | `C-c , t`
+<kbd>M-x rspec-toggle-spec-and-target-find-example</kbd>            | Toggle back and forth between a method and its examples in the spec file                                                  | `C-c , e`
+<kbd>M-x rspec-find-spec-or-target-other-window</kbd>               | Find in the other window the spec or the target file                                                                      | `C-c , 4 t`
+<kbd>M-x rspec-find-spec-or-target-find-example-other-window</kbd>  | Find in the other window the spec or the target file, and try to navigate to the example or method corresponding to point | `C-c , 4 e`
+<kbd>M-x rspec-rerun</kbd>                                          | Re-run the last verification process                                                                                      | `C-c , r`
+<kbd>M-x rspec-verify-matching</kbd>                                | Run all specs related to the current buffer                                                                               | `C-c , m`
+<kbd>M-x rspec-verify-continue</kbd>                                | Run the current spec and all after it                                                                                     | `C-c , c`
+<kbd>M-x rspec-verify-method</kbd>                                  | Verify the example or method defined at point                                                                             | `C-c , s`
+<kbd>M-x rspec-run-last-failed</kbd>                                | Re-run just the failed examples from the last run                                                                         | `C-c , f`
+
+Command                                         | Description                                    | RSpec mode binding
+------------------------------------------------|------------------------------------------------|-------------------
+<kbd>M-x rspec-verify-single</kbd>              | Run the specified example at point             | `C-c , s`
+<kbd>M-x rspec-toggle-example-pendingness</kbd> | Toggle the pendingness of the example at point | `C-c , d`
+
+Command                                  | Description                                                    | RSpec Dired mode binding
+-----------------------------------------|----------------------------------------------------------------|-------------------------
+<kbd>M-x rspec-dired-verify</kbd>        | Run all specs in the current directory                         | `C-c , v`
+<kbd>M-x rspec-dired-verify-single</kbd> | Run marked specs or spec at point (works with directories too) | `C-c , s`
+<kbd>M-x rspec-verify-all</kbd>          | Run the 'spec' rake task for the project of the current file   | `C-c , a`
+<kbd>M-x rspec-rerun</kbd>               | Re-run the last RSpec invocation                               | `C-c , r`
+
 See `rspec-mode.el` for further usage.
 
 ## Gotchas
@@ -35,7 +61,7 @@ To use `binding.pry` or `byebug`, install `inf-ruby` and add this to
 your init file:
 
 ```emacs
-(add-hook 'after-init-hook 'inf-ruby-switch-setup) 
+(add-hook 'after-init-hook 'inf-ruby-switch-setup)
 ```
 
 When you've hit the breakpoint, hit `C-x C-q` to enable `inf-ruby`.

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -25,35 +25,9 @@
 
 ;;; Commentary:
 ;;
-;; This minor mode provides some enhancements to ruby-mode in
-;; the contexts of RSpec specifications.  Namely, it provides the
-;; following capabilities:
-;;
-;;  * toggle back and forth between a spec and its target (bound to
-;;    `\C-c ,t`)
-;;
-;;  * toggle back and forth between a method and its examples in the spec file
-;;    (bound to `\C-c ,e`)
-;;
-;;  * verify the spec file associated with the current buffer (bound to `\C-c ,v`)
-;;
-;;  * verify the example or method defined at point (bound to `\C-c ,s`)
-;;
-;;  * re-run the last verification process (bound to `\C-c ,r`)
-;;
-;;  * re-run just the failed examples from the last run (bound to `\C-c ,f`)
-;;
-;;  * toggle the pendingness of the example at point (bound to `\C-c ,d`)
-;;
-;;  * disable the example at point by making it pending
-;;
-;;  * reenable the disabled example at point
-;;
-;;  * run all specs related to the current buffer (`\C-c ,m`)
-;;
-;;  * run the current spec and all after it (`\C-c ,c`)
-;;
-;;  * run spec for entire project (bound to `\C-c ,a`)
+;; This minor mode provides some enhancements to ruby-mode in the
+;; contexts of RSpec specifications.  Refer to the README for a
+;; summary of keybindings and their descriptions.
 ;;
 ;; You can choose whether to run specs using 'rake spec' or the 'spec'
 ;; command. Use the customization interface (customize-group


### PR DESCRIPTION
I added the keybindings to the README as I've grown accustomed to finding them there (I'm thinking of Projectile, Rubocop mode, etc...) I missed the first few times I visited the project that they were documented in the `rspec-mode.el` file itself. Not a big deal if you'd prefer not to have them here though.