### PR TITLE
add ability to specify .zeus.sock path

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -566,9 +566,13 @@ file if it exists, or sensible defaults otherwise."
   (and rspec-use-bundler-when-possible
        (file-readable-p (concat (rspec-project-root) "Gemfile"))))
 
+(defun rspec-zeus-file-path ()
+  (or (getenv "ZEUSSOCK")
+      (concat (rspec-project-root) ".zeus.sock")))
+
 (defun rspec-zeus-p ()
   (and rspec-use-zeus-when-possible
-       (file-exists-p (concat (rspec-project-root) ".zeus.sock"))))
+       (file-exists-p (rspec-zeus-file-path))))
 
 (defun rspec-rake-p ()
   (and rspec-use-rake-when-possible


### PR DESCRIPTION
since you can specify the socket path to zeus via an environment variable, this lets us override the default (project_root/.zeus.sock) via a variable (in my specific case, "/tmp/zeus.sock").