### PR TITLE
Check SPRING_DISABLE environment variable

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -583,6 +583,7 @@ file if it exists, or sensible defaults otherwise."
 
 (defun rspec-spring-p ()
   (and rspec-use-spring-when-possible
+       (not (equal (getenv "SPRING_DISABLE") "1"))
        (let ((root (directory-file-name (rspec-project-root))))
          (or
           ;; Older versions


### PR DESCRIPTION
This adds a check for the [`SPRING_DISABLE`](https://github.com/rails/spring#temporarily-disabling-spring) environment variable. 

Also note that even though Spring was not running it still tried to execute `spring rspec ...`. This resulted in Spring's usage. 