### PR TITLE
Add ability to execute external command after each spec run

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ Keybinding | Description                                                    |
 
 See `rspec-mode.el` for further usage.
 
+### System notifications
+
+If `rspec-notification-command` is set to a command string, it will be
+used to display notificaitons after every RSpec run.
+
+For example, with `terminal-notifier` installed on OSX this variable can be set to:
+
+```
+(custom-set-variables
+ '(rspec-notification-command "terminal-notifier -message"))
+```
+
 ## Gotchas
 ### Debugging
 

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -51,6 +51,7 @@
 ;;
 ;;; Change Log:
 ;;
+;; 1.14 - Add `rspec-notification-command' variable, that defines notification command
 ;; 1.13 - Add a variable to autosave current buffer where it makes sense
 ;; 1.12 - Run specs for single method (Renan Ranelli)
 ;; 1.11 - Switching between method, its specs and back (Renan Ranelli)
@@ -169,6 +170,11 @@ Not used when running specs using Zeus or Spring."
 
 (defcustom rspec-command-options "--format documentation"
   "Default options used with rspec-command."
+  :type 'string
+  :group 'rspec-mode)
+
+(defcustom rspec-notification-command nil
+  "Command used to send notification after rspec-command is finished."
   :type 'string
   :group 'rspec-mode)
 
@@ -726,7 +732,18 @@ or a cons (FILE . LINE), to run one example."
   "Compilation mode for RSpec output."
   (add-hook 'compilation-filter-hook 'rspec-colorize-compilation-buffer nil t)
   (add-hook 'compilation-finish-functions 'rspec-store-failures nil t)
-  (add-hook 'compilation-finish-functions 'rspec-handle-error nil t))
+  (add-hook 'compilation-finish-functions 'rspec-handle-error nil t)
+  (add-hook 'compilation-finish-functions 'rspec-send-notification nil t))
+
+(defun rspec-send-notification (&rest ignore)
+  (if rspec-notification-command
+      (progn
+        (rspec-store-failures)
+        (let* ((failures-count (length rspec-last-failed-specs))
+               (command (format "%s \"RSpec finished failures: %d\""
+                                rspec-notification-command
+                                failures-count)))
+          (shell-command command)))))
 
 (defun rspec-store-failures (&rest ignore)
   "Store the file and line number of the failed examples from this run."


### PR DESCRIPTION
This adds `rspec-notification-command`. If this variable is set to something other then nil, it will be executed as a shell command after each spec run.

This can be used for system notification, especially in projects where Gemfile can't be changed and because of that projects such as https://github.com/twe4ked/rspec-nc can't be used.

For example I have `(rspec-notification-command "terminal-notifier -message")` in my `custom-set-variables` block, which in result gives me this when I run my specs:

![rspec-notifications](https://cloud.githubusercontent.com/assets/25693/10527785/cdd5a4c0-7392-11e5-8211-f4b025026bb4.gif)
