### PR TITLE
Fix Spring-checking on 1.5+

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -601,9 +601,13 @@ file if it exists, or sensible defaults otherwise."
           ;; 0.9.2+
           (file-exists-p (format "%s/spring/%s.pid" temporary-file-directory (md5 root)))
           ;; 1.2.0+
-          (let ((path (or (getenv "XDG_RUNTIME_DIR") temporary-file-directory))
-                (ruby-version (shell-command-to-string "ruby -e 'print RUBY_VERSION'")))
-            (file-exists-p (format "%s/spring/%s.pid" path (md5 (concat ruby-version root)))))))))
+          (let* ((path (or (getenv "XDG_RUNTIME_DIR") temporary-file-directory))
+                 (ruby-version (shell-command-to-string "ruby -e 'print RUBY_VERSION'"))
+                 (application-id (md5 (concat ruby-version root))))
+            (or
+             (file-exists-p (format "%s/spring/%s.pid" path application-id))
+             ;; 1.5.0+
+             (file-exists-p (format "%s/spring-%s/%s.pid" path (user-real-uid) application-id))))))))
 
 (defun rspec2-p ()
   (or (string-match "rspec" rspec-spec-command)


### PR DESCRIPTION
Hi there - Spring 1.5 changes its pid file location again, to incorporate the current user's uid (https://github.com/rails/spring/commit/9bdba373b2d46b4506a6de3cf94c6413a4d35fb3).   How about the attached?

(First time writing elisp, so feel free to criticise any weirdness there)