### PR TITLE
Correctly match capybara-screenshot output

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -726,8 +726,8 @@ or a cons (FILE . LINE), to run one example."
      (1 compilation-error-face))))
 
 (defvar rspec-compilation-error-regexp-alist-alist
-  '((rspec-capybara-html "Saved file \\([0-9A-Za-z@_./\:-]+\\.html\\)" 1 nil nil 0 1)
-    (rspec-capybara-screenshot "Screenshot: \\([0-9A-Za-z@_./\:-]+\\.png\\)" 1 nil nil 0 1)
+  '((rspec-capybara-html "screenshot: \\([0-9A-Za-z@_./\:-]+\\.html\\)" 1 nil nil 0 1)
+    (rspec-capybara-screenshot "screenshot: \\([0-9A-Za-z@_./\:-]+\\.png\\)" 1 nil nil 0 1)
     (rspec "^ +# \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\):in" 1 2 nil 2 1)
     (rspec-pendings "^ +# \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 1 1)
     (rspec-summary "^rspec \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 2 1)))

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -726,8 +726,8 @@ or a cons (FILE . LINE), to run one example."
      (1 compilation-error-face))))
 
 (defvar rspec-compilation-error-regexp-alist-alist
-  '((rspec-capybara-html "screenshot: \\([0-9A-Za-z@_./\:-]+\\.html\\)" 1 nil nil 0 1)
-    (rspec-capybara-screenshot "screenshot: \\([0-9A-Za-z@_./\:-]+\\.png\\)" 1 nil nil 0 1)
+  '((rspec-capybara-html "screenshot: file://\\([0-9A-Za-z@_./\:-]+\\.html\\)" 1 nil nil 0 1)
+    (rspec-capybara-screenshot "screenshot: file://\\([0-9A-Za-z@_./\:-]+\\.png\\)" 1 nil nil 0 1)
     (rspec "^ +# \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\):in" 1 2 nil 2 1)
     (rspec-pendings "^ +# \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 1 1)
     (rspec-summary "^rspec \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 2 1)))


### PR DESCRIPTION
It appears upstream capybara-screenshot changed the output for reporting
screenshot failures:

https://github.com/mattheworiordan/capybara-screenshot/commit/4247c4296fc1a0cd8bf10a897f2511f0ed612435#diff-814c9a0aeab384689919406b7d82dabdL15

Updates the regex to match. It unfortunately doesn't entirely work,
because the link is of format
`file://$current_working_dir/path/to/screenshot{.png,.html}`. After
hitting enter emacs prompts with that as the default but doesn't seem to
find the resulting file.

At the very least this fixes the links to be detected correctly, not
sure on restoring the functionality to open on click.