### PR TITLE
Add option to run specs inside a Vagrant box

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ specs. This piece of code does the job:
 (ad-activate 'rspec-compile)
 ```
 
+### Vagrant
+
+You can run specs inside a vagrant box. You can enable it through the
+`rspec-use-vagrant-when-possible` customization option. You can also set the
+directory where you're project is inside your box through the
+`rspec-vagrant-cwd` option. This will run specs through the `vagrant ssh -c 'cd
+<cwd>; <rspec command>'`.
+
 ### Auto-scrolling
 
 Set `compilation-scroll-output`. For example, `(setq compilation-scroll-output t)`

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ specs. This piece of code does the job:
 
 ### Vagrant
 
-You can run specs inside a vagrant box. You can enable it through the
+You can run specs inside a Vagrant box. You can enable it through the
 `rspec-use-vagrant-when-possible` customization option. You can also set the
 directory where you're project is inside your box through the
 `rspec-vagrant-cwd` option. This will run specs through the `vagrant ssh -c 'cd

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ specs. This piece of code does the job:
 
 You can run specs inside a Vagrant box. You can enable it through the
 `rspec-use-vagrant-when-possible` customization option. You can also set the
-directory where you're project is inside your box through the
+directory where your project is inside your box through the
 `rspec-vagrant-cwd` option. This will run specs through the `vagrant ssh -c 'cd
 <cwd>; <rspec command>'`.
 

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -143,7 +143,7 @@
   :type 'boolean
   :group 'rspec-mode)
 
-(defcustom rspec-vagrant-cwd "~/"
+(defcustom rspec-vagrant-cwd "/vagrant/"
   "Working directory when running inside Vagrant. Use trailing slash."
   :type 'string
   :group 'rspec-mode)

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -645,19 +645,20 @@ file if it exists, or sensible defaults otherwise."
     (expand-file-name "spec.opts" (rspec-spec-directory (rspec-project-root)))))
 
 (defun rspec--shell-quote-local (file)
-  (let ((remote (file-remote-p file)))
+  (let ((remote (file-remote-p file))
+        (vagrant (rspec-vagrant-p)))
     (shell-quote-argument
-     (if remote
-         (substring file (length remote))
-       file))))
+     (cond
+      (remote (substring file (length remote)))
+      (vagrant (replace-regexp-in-string (regexp-quote (rspec-project-root))
+                                         rspec-vagrant-cwd file))
+      (t  file)))))
 
 (defun rspec--vagrant-wrapper (command)
   (if (rspec-vagrant-p)
       (format "vagrant ssh -c 'cd %s; %s'"
-              rspec-vagrant-cwd
-              (replace-regexp-in-string (rspec-project-root)
-                                        rspec-vagrant-cwd
-                                        command))
+              (shell-quote-argument rspec-vagrant-cwd)
+              command)
     command))
 
 (defun rspec-runner ()

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -51,6 +51,8 @@
 ;;
 ;;; Change Log:
 ;;
+;; 1.14 - Add option to run spec commands in a vagrant box through
+;;        "vagrant ssh -c".
 ;; 1.13 - Add a variable to autosave current buffer where it makes sense
 ;; 1.12 - Run specs for single method (Renan Ranelli)
 ;; 1.11 - Switching between method, its specs and back (Renan Ranelli)
@@ -141,9 +143,19 @@
   :type 'boolean
   :group 'rspec-mode)
 
+(defcustom rspec-vagrant-cwd "~/"
+  "Working directory when running inside vagrant. Use trailing slash."
+  :type 'string
+  :group 'rspec-mode)
+
 (defcustom rspec-use-bundler-when-possible t
   "When t and Gemfile is present, run specs with 'bundle exec'.
 Not used when running specs using Zeus or Spring."
+  :type 'boolean
+  :group 'rspec-mode)
+
+(defcustom rspec-use-vagrant-when-possible nil
+  "When t and Vagrant file is present, run specs inside vagrant box using 'vagrant ssh -c'."
   :type 'boolean
   :group 'rspec-mode)
 
@@ -586,6 +598,10 @@ file if it exists, or sensible defaults otherwise."
   (and rspec-use-bundler-when-possible
        (file-readable-p (concat (rspec-project-root) "Gemfile"))))
 
+(defun rspec-vagrant-p ()
+  (and rspec-use-vagrant-when-possible
+       (file-readable-p (concat (rspec-project-root) "Vagrantfile"))))
+
 (defun rspec-zeus-file-path ()
   (or (getenv "ZEUSSOCK")
       (concat (rspec-project-root) ".zeus.sock")))
@@ -634,6 +650,15 @@ file if it exists, or sensible defaults otherwise."
      (if remote
          (substring file (length remote))
        file))))
+
+(defun rspec--vagrant-wrapper (command)
+  (if (rspec-vagrant-p)
+      (format "vagrant ssh -c 'cd %s; %s'"
+              rspec-vagrant-cwd
+              (replace-regexp-in-string (rspec-project-root)
+                                        rspec-vagrant-cwd
+                                        command))
+    command))
 
 (defun rspec-runner ()
   "Return command line to run rspec."
@@ -718,9 +743,10 @@ or a cons (FILE . LINE), to run one example."
       (rvm-activate-corresponding-ruby))
 
   (let ((default-directory (or (rspec-project-root) default-directory)))
-    (compile (mapconcat 'identity `(,(rspec-runner)
-                                    ,(rspec-runner-options opts)
-                                    ,target) " ")
+    (compile (rspec--vagrant-wrapper
+              (mapconcat 'identity `(,(rspec-runner)
+                                     ,(rspec-runner-options opts)
+                                     ,target) " "))
              'rspec-compilation-mode)))
 
 (defvar rspec-compilation-mode-font-lock-keywords

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -51,7 +51,7 @@
 ;;
 ;;; Change Log:
 ;;
-;; 1.14 - Add option to run spec commands in a vagrant box through
+;; 1.14 - Add option to run spec commands in a Vagrant box through
 ;;        "vagrant ssh -c".
 ;; 1.13 - Add a variable to autosave current buffer where it makes sense
 ;; 1.12 - Run specs for single method (Renan Ranelli)
@@ -144,7 +144,7 @@
   :group 'rspec-mode)
 
 (defcustom rspec-vagrant-cwd "~/"
-  "Working directory when running inside vagrant. Use trailing slash."
+  "Working directory when running inside Vagrant. Use trailing slash."
   :type 'string
   :group 'rspec-mode)
 
@@ -155,7 +155,7 @@ Not used when running specs using Zeus or Spring."
   :group 'rspec-mode)
 
 (defcustom rspec-use-vagrant-when-possible nil
-  "When t and Vagrant file is present, run specs inside vagrant box using 'vagrant ssh -c'."
+  "When t and Vagrant file is present, run specs inside Vagrant box using 'vagrant ssh -c'."
   :type 'boolean
   :group 'rspec-mode)
 


### PR DESCRIPTION
I started working on a rails project that has a vagrant development box
configured and instead of trying to configure a local environment to run
my specs from emacs on my host machine, I decided to give it a go at
implementing vagrant support for rspec-mode. Take a look and see if you
like it!