### PR TITLE
Get tests passing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
+EMACS ?= emacs
+
+.PHONY: elpa clean test
+
+test:
+	${EMACS} -Q --batch -l ert --directory . -l test/rspec-mode-test.el \
+	         --eval '(ert-run-tests-batch-and-exit)'
+
 elpa: *.el
 	@version=`grep -o "Version: .*" rspec-mode.el | cut -c 10-`; \
 	dir=rspec-mode-$$version; \

--- a/test/rspec-mode-test.el
+++ b/test/rspec-mode-test.el
@@ -27,4 +27,5 @@
   "matches pending specs as info"
   (let ((example "    # ./spec/controllers/pages_controller_spec.rb:65"))
     (should-not (rspec--test-compilation-match-p example 'error))
-    (should (rspec--test-compilation-match-p example 'info))))
+    (should-not (rspec--test-compilation-match-p example 'info))
+    (should (rspec--test-compilation-match-p example 'warning))))

--- a/test/rspec-mode-test.el
+++ b/test/rspec-mode-test.el
@@ -1,4 +1,6 @@
 ;; -*- lexical-binding: t; -*-
+(require 'cl-lib)
+(require 'ert)
 (require 'rspec-mode)
 
 ;;; Test regexp matches in compilation buffer
@@ -7,7 +9,7 @@
   (let* ((type (or type 'error))
          (types '((error . 2) (warning . 1) (info . 0)))
          (type-num (cdr (assq type types))))
-    (some (lambda (n) (and (string-match (nth 1 n) example) (= type-num (nth 5 n)))) rspec-compilation-error-regexp-alist-alist)))
+    (cl-some (lambda (n) (and (string-match (nth 1 n) example) (= type-num (nth 5 n)))) rspec-compilation-error-regexp-alist-alist)))
 
 (ert-deftest rspec--test-regexp-backtrace ()
   "matches backtrace"

--- a/test/rspec-mode-test.el
+++ b/test/rspec-mode-test.el
@@ -7,7 +7,7 @@
   (let* ((type (or type 'error))
          (types '((error . 2) (warning . 1) (info . 0)))
          (type-num (cdr (assq type types))))
-    (some (lambda (n) (and (string-match (nth 1 n) example) (= type-num (nth 5 n)))) rspec--compilation-error-regexp-alist-alist)))
+    (some (lambda (n) (and (string-match (nth 1 n) example) (= type-num (nth 5 n)))) rspec-compilation-error-regexp-alist-alist)))
 
 (ert-deftest rspec--test-regexp-backtrace ()
   "matches backtrace"


### PR DESCRIPTION
I was getting failures running the test suite; these are the changes I made to get things going again:

- Pending tests were incorrectly classed as warnings in `rspec-compilation-error-regexp-alist-alist`; now they're info.
- There was a variable typo in `rspec--test-compilation-match-p`
- Without `cl-lib` required by the tests, `some` was undefined.

I went ahead and disambiguated `cl-some`, and added a make target.