### PR TITLE
Adding `rspec-use-pry-rescue` option.

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -226,6 +226,11 @@ for spec files corresponding to files inside them."
   :type 'boolean
   :group 'rspec-mode)
 
+(defcustom rspec-use-pry-rescue nil
+  "If t, prepend `rspec-spec-command' with 'rescue', so that 'pry-rescue' can be used."
+  :type 'boolean
+  :group 'rspec-mode)
+
 ;;;###autoload
 (define-minor-mode rspec-mode
   "Minor mode for RSpec files
@@ -667,6 +672,8 @@ file if it exists, or sensible defaults otherwise."
         (zeus-command (if (rspec-zeus-p) "zeus " nil))
         (spring-command (if (rspec-spring-p) "spring " nil)))
     (concat (or zeus-command spring-command bundle-command)
+            (if rspec-use-pry-rescue
+                "rescue ")
             (if (rspec-rake-p)
                 (concat rspec-rake-command " spec")
               rspec-spec-command))))


### PR DESCRIPTION
This commit introduces the `rspec-use-pry-rescue` option, useful with
the `pry-rescue` (https://github.com/ConradIrwin/pry-rescue) gem.
## 

I couldn't find anything in the docs for how to add options to the `rspec` command line, so I wrote this. Let me know if there are better ways 
