### PR TITLE
Add `rspec-after-verification-hook`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ Keybinding | Description                                                    |
 
 See `rspec-mode.el` for further usage.
 
+### Before verification hook
+
+Any functions in `rspec-before-verification-hook` will be executed
+before the verification - `rspec-verify` and variants.
+
+### After verification hook
+
+Any functions in `rspec-after-verification-hook` will be executed
+after the verification - `rspec-verify` and variants. The hook will be
+executed whatever the outcome of the verification.
+
 ## Gotchas
 ### Debugging
 


### PR DESCRIPTION
This hook will be run as the last `compilation-finish-function` at the
end of having run `rspec-verify` or its variants.

This should handle the use case for #130. It follows the advice of those comments making the generic hook.
