### PR TITLE
Added support for running rspec in docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,23 @@ directory where your project is inside your box through the
 `rspec-vagrant-cwd` option. This will run specs through the `vagrant ssh -c 'cd
 <cwd>; <rspec command>'`.
 
+### Docker
+
+You can run specs inside a Docker container. This can be enabled through the
+`rspec-use-docker-when-possible` option. This enabled, rspec is executed
+through `docker-compose run`.
+The following customization options are available:
+
+Option                           | Default value         | Description                                  |
+---------------------------------|-----------------------|-----------------------                       |
+`rspec-use-docker-when-possible` | `nil`                 | Enable docker                                |
+`rspec-docker-command`           | `docker-compose run`  | Docker command to run                        |
+`rspec-docker-cwd`               | `/app/`               | Path rspec to run in inside of the container |
+`rspec-docker-container`         | `rspec-container-name`| Name of the container to run rspec into      |
+
+To define the options for different projects, have a look at [Per-Directory Local Variables](https://www.gnu.org/software/emacs/manual/html_node/emacs/Directory-Variables.html).
+
+
 ### Auto-scrolling
 
 Set `compilation-scroll-output`. For example, `(setq compilation-scroll-output t)`

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -145,13 +145,18 @@
   :type 'boolean
   :group 'rspec-mode)
 
-(defcustom rspec-docker-container "container"
-  "Name of the docker container to run rspec in"
+(defcustom rspec-docker-command "docker-compose run"
+  "Docker command to run."
+  :type 'string
+  :group 'rspec-mode)
+
+(defcustom rspec-docker-container "rspec-container-name"
+  "Name of the docker container to run rspec in."
   :type 'string
   :group 'rspec-mode)
 
 (defcustom rspec-docker-cwd "/app/"
-  "Working directory when running inside Docker. Use trailing slash."
+  "Working directory when running inside Docker.  Use trailing slash."
   :type 'string
   :group 'rspec-mode)
 
@@ -680,7 +685,8 @@ file if it exists, or sensible defaults otherwise."
 
 (defun rspec--docker-wrapper (command)
   (if (rspec-docker-p)
-      (format "docker exec %s bash -c \"%s\""
+      (format "%s %s bash -c \"%s\""
+              rspec-docker-command
               rspec-docker-container
               command)
     command))


### PR DESCRIPTION
I am no Lisp programmer, so somebody with more experience should have a look. Also my code could effect the vagrant support, I have not tested this.

I have tested the docker support for rspec with Emacs 25.1.1 running on Windows 10.
To use it, rspec-use-docker-when-possible has to be t, rspec-docker-container must be the name of the running container and rspec-docker-cwd should name the directory of the rails application inside of the docker container.