### PR TITLE
Canonicalize `(rspec-project-root)`

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -849,9 +849,9 @@ or a cons (FILE . LINE), to run one example."
   (let ((directory (file-name-as-directory (or directory default-directory))))
     (cond ((rspec-root-directory-p directory)
            (error "Could not determine the project root."))
-          ((file-exists-p (expand-file-name "Rakefile" directory)) directory)
-          ((file-exists-p (expand-file-name "Gemfile" directory)) directory)
-          ((file-exists-p (expand-file-name "Berksfile" directory)) directory)
+          ((file-exists-p (expand-file-name "Rakefile" directory)) (expand-file-name directory))
+          ((file-exists-p (expand-file-name "Gemfile" directory)) (expand-file-name directory))
+          ((file-exists-p (expand-file-name "Berksfile" directory)) (expand-file-name directory))
           (t (rspec-project-root (file-name-directory (directory-file-name directory)))))))
 
 (defun rspec--include-fg-syntax-methods-p ()


### PR DESCRIPTION
Currently, `(rspec-project-root)` might return values in different notations depending on which buffer the function is invoked, using either `~` or the expanded version for the `$HOME` folder. This is affecting other functions that rely on string substitutions such as `(rspec--shell-quote-local)`.
More specifically, I'm not being able to run `rspec` from `dired` buffers using the docker integration.
A simple workaround for this is to always return the fully expanded path from `(rspec-project-root)`.