### PR TITLE
Add `rspec-use-chruby`

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -147,6 +147,11 @@
   :type 'boolean
   :group 'rspec-mode)
 
+(defcustom rspec-use-chruby nil
+  "When t, use chruby. Requires chruby.el."
+  :type 'boolean
+  :group 'rspec-mode)
+
 (defcustom rspec-docker-command "docker-compose run"
   "Docker command to run."
   :type 'string
@@ -789,6 +794,9 @@ or a cons (FILE . LINE), to run one example."
 
   (if rspec-use-rvm
       (rvm-activate-corresponding-ruby))
+
+  (if rspec-use-chruby
+      (chruby-use-corresponding))
 
   (let ((default-directory (or (rspec-project-root) default-directory)))
     (compile


### PR DESCRIPTION
Like rvm implementation, we can use `chruby-use-corresponding` to select the
right ruby version with chruby before executing the test.

This relies on [chruby.el](https://github.com/plexus/chruby.el)