### PR TITLE
Swap Gemfile & Rakefile check to find project root

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -872,8 +872,8 @@ or a cons (FILE . LINE), to run one example."
   (let ((directory (file-name-as-directory (or directory default-directory))))
     (cond ((rspec-root-directory-p directory)
            (error "Could not determine the project root."))
-          ((file-exists-p (expand-file-name "Rakefile" directory)) (expand-file-name directory))
           ((file-exists-p (expand-file-name "Gemfile" directory)) (expand-file-name directory))
+          ((file-exists-p (expand-file-name "Rakefile" directory)) (expand-file-name directory))
           ((file-exists-p (expand-file-name "Berksfile" directory)) (expand-file-name directory))
           (t (rspec-project-root (file-name-directory (directory-file-name directory)))))))
 


### PR DESCRIPTION
Hi!

I'm using Spacemacs and latest released version of this mode in order to work with Decidim:

https://github.com/decidim/decidim

I have `rspec-use-bundler-when-possible` set to `t`.

Whenever I try to run a test like the following it fails, because it doesn't properly use bundler.

https://github.com/decidim/decidim/blob/master/decidim-comments/spec/mailers/comment_notification_mailer_spec.rb

If you check the structure, we only have one Gemfile, but each subfolder has a Rakefile. This causes this mode to fail to successfully find the project root, so the `rspec-use-bundler-when-possible` fails when set to `t` because it tries to find a `Gemfile` in the folder it considers to be the project root, but there isn't any. This causes the mode to not use `bundle exec`, so the rspec command fails.

I don't know how to properly test this, and I don't know if there's a better solution for this (manually setting the project root, maybe?). If you think there's a better way to fix my problem please close this PR! :)

Thanks for your work!