### PR TITLE
Set safe function for string defcustom variables

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -51,7 +51,7 @@
 ;;
 ;;; Change Log:
 ;;
-;; 1.17 - Set :safe on defcustom string variables for .dir-local.el use
+;; 1.17 - Set :safe on rspec-docker-command for .dir-local.el use
 ;; 1.16 - Add `rspec-yank-last-command' function (Sergiy Kukunin)
 ;; 1.15 - Add option to run spec commands in a Docker container
 ;;        through "docker exec".
@@ -136,13 +136,11 @@
 (defcustom rspec-rake-command "rake"
   "The command for rake."
   :type 'string
-  :safe 'stringp
   :group 'rspec-mode)
 
 (defcustom rspec-spec-command "rspec"
   "The command for spec."
   :type 'string
-  :safe 'stringp
   :group 'rspec-mode)
 
 (defcustom rspec-use-rvm nil
@@ -158,25 +156,23 @@
 (defcustom rspec-docker-command "docker-compose run"
   "Docker command to run."
   :type 'string
-  :safe 'stringp
+  :safe '(lambda (symbol value)
+           (member value '("docker-compose run" "docker-compose exec")))
   :group 'rspec-mode)
 
 (defcustom rspec-docker-container "rspec-container-name"
   "Name of the docker container to run rspec in."
   :type 'string
-  :safe 'stringp
   :group 'rspec-mode)
 
 (defcustom rspec-docker-cwd "/app/"
   "Working directory when running inside Docker.  Use trailing slash."
   :type 'string
-  :safe 'stringp
   :group 'rspec-mode)
 
 (defcustom rspec-vagrant-cwd "/vagrant/"
   "Working directory when running inside Vagrant. Use trailing slash."
   :type 'string
-  :safe 'stringp
   :group 'rspec-mode)
 
 (defcustom rspec-use-bundler-when-possible t
@@ -213,13 +209,11 @@ Not used when running specs using Zeus or Spring."
 (defcustom rspec-key-command-prefix  (kbd "C-c ,")
   "The prefix for all rspec related key commands."
   :type 'string
-  :safe 'stringp
   :group 'rspec-mode)
 
 (defcustom rspec-command-options "--format documentation"
   "Default options used with rspec-command."
   :type 'string
-  :safe 'stringp
   :group 'rspec-mode)
 
 (defcustom rspec-snippets-fg-syntax nil

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -4,7 +4,7 @@
 ;; Author: Peter Williams, et al.
 ;; URL: http://github.com/pezra/rspec-mode
 ;; Created: 2011
-;; Version: 1.16
+;; Version: 1.17
 ;; Keywords: rspec ruby
 ;; Package-Requires: ((ruby-mode "1.0") (cl-lib "0.4"))
 
@@ -51,6 +51,7 @@
 ;;
 ;;; Change Log:
 ;;
+;; 1.17 - Set :safe on defcustom string variables for .dir-local.el use
 ;; 1.16 - Add `rspec-yank-last-command' function (Sergiy Kukunin)
 ;; 1.15 - Add option to run spec commands in a Docker container
 ;;        through "docker exec".
@@ -135,11 +136,13 @@
 (defcustom rspec-rake-command "rake"
   "The command for rake."
   :type 'string
+  :safe 'stringp
   :group 'rspec-mode)
 
 (defcustom rspec-spec-command "rspec"
   "The command for spec."
   :type 'string
+  :safe 'stringp
   :group 'rspec-mode)
 
 (defcustom rspec-use-rvm nil
@@ -155,21 +158,25 @@
 (defcustom rspec-docker-command "docker-compose run"
   "Docker command to run."
   :type 'string
+  :safe 'stringp
   :group 'rspec-mode)
 
 (defcustom rspec-docker-container "rspec-container-name"
   "Name of the docker container to run rspec in."
   :type 'string
+  :safe 'stringp
   :group 'rspec-mode)
 
 (defcustom rspec-docker-cwd "/app/"
   "Working directory when running inside Docker.  Use trailing slash."
   :type 'string
+  :safe 'stringp
   :group 'rspec-mode)
 
 (defcustom rspec-vagrant-cwd "/vagrant/"
   "Working directory when running inside Vagrant. Use trailing slash."
   :type 'string
+  :safe 'stringp
   :group 'rspec-mode)
 
 (defcustom rspec-use-bundler-when-possible t
@@ -206,11 +213,13 @@ Not used when running specs using Zeus or Spring."
 (defcustom rspec-key-command-prefix  (kbd "C-c ,")
   "The prefix for all rspec related key commands."
   :type 'string
+  :safe 'stringp
   :group 'rspec-mode)
 
 (defcustom rspec-command-options "--format documentation"
   "Default options used with rspec-command."
   :type 'string
+  :safe 'stringp
   :group 'rspec-mode)
 
 (defcustom rspec-snippets-fg-syntax nil


### PR DESCRIPTION
Using the following `.dir-locals.el` file...

```el
;;; Directory Local Variables
;;; For more information see (info "(emacs) Directory Variables")

((nil
  (rspec-use-docker-when-possible . t)
  (rspec-docker-command . "docker-compose exec")
  (rspec-docker-container . "core"))
 )
```

I was getting the error: (sorry couldn't copy out of emacs... and buffer gone after proceeding)
![screen shot 2017-10-19 at 4 11 33 pm](https://user-images.githubusercontent.com/328491/31794606-7afe47f4-b4e8-11e7-942c-7e4fa9ccde12.png)

My lisp is super rusty, but after some fidgeting around and reading about this dir-locals and error, I learned that there should be a `:safe` function that identifies safe values. Using `stringp` solved it for `rspec-docker-command`, and so I figured it should be applied to the other string variables. I'm not sure why I don't get a warning about `core`.

I also tried to learn `ert` and figure out a way to test the `dir-locals-read-from-file` method but while I got the test passing... I couldn't get it failing, which indicates to me that I wasn't testing what I thought I was.

Anyways, here's a PR for my hack.