### PR TITLE
Support for running multiple rspec processes at once

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -914,18 +914,18 @@ Looks at FactoryGirl::Syntax::Methods usage in spec_helper."
       method
     (concat "FactoryGirl." method)))
 
-(defvar rspec-process-count 0)
+(defvar rspec-running-process-count 0)
 
 (defun rspec-compilation-buffer-name (&rest ignore)
-  (if (= rspec-process-count 0)
+  (if (= rspec-running-process-count 0)
       "*rspec-compilation*"
-    (format "*rspec-compilation* <%d>" rspec-process-count)))
+    (format "*rspec-compilation* <%d>" rspec-running-process-count)))
 
 (defun rspec-increment-process-count (&rest ignore)
-  (setq rspec-process-count (1+ rspec-process-count)))
+  (setq rspec-running-process-count (1+ rspec-running-process-count)))
 
 (defun rspec-decrement-process-count (&rest ignore)
-  (setq rspec-process-count (1- rspec-process-count)))
+  (setq rspec-running-process-count (1- rspec-running-process-count)))
 
 ;;;###autoload
 (defun rspec-enable-appropriate-mode ()

--- a/test/rspec-mode-test.el
+++ b/test/rspec-mode-test.el
@@ -29,3 +29,10 @@
     (should-not (rspec--test-compilation-match-p example 'error))
     (should-not (rspec--test-compilation-match-p example 'info))
     (should (rspec--test-compilation-match-p example 'warning))))
+
+(ert-deftest rspec--test-compilation-buffer-name ()
+  "buffer-name is named with `rspec-process-count'"
+  (let ((rspec-process-count 0))
+    (should (equal (rspec-compilation-buffer-name) "*rspec-compilation*")))
+  (let ((rspec-process-count 1))
+    (should (equal (rspec-compilation-buffer-name) "*rspec-compilation* <1>"))))

--- a/test/rspec-mode-test.el
+++ b/test/rspec-mode-test.el
@@ -29,10 +29,3 @@
     (should-not (rspec--test-compilation-match-p example 'error))
     (should-not (rspec--test-compilation-match-p example 'info))
     (should (rspec--test-compilation-match-p example 'warning))))
-
-(ert-deftest rspec--test-compilation-buffer-name ()
-  "compilation buffer name is named with `rspec-running-process-count'"
-  (let ((rspec-running-process-count 0))
-    (should (equal (rspec-compilation-buffer-name) "*rspec-compilation*")))
-  (let ((rspec-running-process-count 1))
-    (should (equal (rspec-compilation-buffer-name) "*rspec-compilation* <1>"))))

--- a/test/rspec-mode-test.el
+++ b/test/rspec-mode-test.el
@@ -31,8 +31,8 @@
     (should (rspec--test-compilation-match-p example 'warning))))
 
 (ert-deftest rspec--test-compilation-buffer-name ()
-  "buffer-name is named with `rspec-process-count'"
-  (let ((rspec-process-count 0))
+  "compilation buffer name is named with `rspec-running-process-count'"
+  (let ((rspec-running-process-count 0))
     (should (equal (rspec-compilation-buffer-name) "*rspec-compilation*")))
-  (let ((rspec-process-count 1))
+  (let ((rspec-running-process-count 1))
     (should (equal (rspec-compilation-buffer-name) "*rspec-compilation* <1>"))))


### PR DESCRIPTION
#169 

Names the rspec compilation buffer with current target. It is stored in the head of `rspec-last-arguments` variable.

Buffer name candidates are:

 1. `*rspec-compilation*`
 2. `*rspec-compilation* <foo_spec>`
 3. `*rspec-compilation* <my_project>`
 4. `*rspec-compilation* <my_project/foo_spec>`
 5. `*rspec-compilation* <my_project/spec/models/foo_spec>`

2 is excluded if the target is not a spec file (ex. runs with `C-c , a`).
3, 4 and 5 are excluded if the target is not in any project.
The first spec file name is used for buffer name if multiple spec files are targeted.

If all candidates are used, it fails to run the new process until some other processes have done.