### PR TITLE
Add `rspec-before-verification-hook` and `rspec-after-verification-hook`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,15 +67,13 @@ Keybinding | Description                                                    |
 
 See `rspec-mode.el` for further usage.
 
-### Before verification hook
+### Hooks
 
 Any functions in `rspec-before-verification-hook` will be executed
-before the verification - `rspec-verify` and variants.
-
-### After verification hook
+before the verification (`rspec-verify`) and variants.
 
 Any functions in `rspec-after-verification-hook` will be executed
-after the verification - `rspec-verify` and variants. The hook will be
+after the verification (`rspec-verify`) and variants. The hook will be
 executed whatever the outcome of the verification.
 
 ## Gotchas

--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ Keybinding | Description                                                    |
 
 See `rspec-mode.el` for further usage.
 
+### Before verification hook
+
+Any functions in `rspec-before-verification-hook` will be executed
+before the verification - `rspec-verify` and variants.
+
+### After verification hook
+
+Any functions in `rspec-after-verification-hook` will be executed
+after the verification - `rspec-verify` and variants. The hook will be
+executed whatever the outcome of the verification.
+
 ## Gotchas
 ### Debugging
 

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -845,7 +845,7 @@ or a cons (FILE . LINE), to run one example."
 
 (define-compilation-mode rspec-compilation-mode "RSpec Compilation"
   "Compilation mode for RSpec output."
-  (add-hook 'compilation-start-hook 'rspec-run-before-verification-hooks nil nil)
+  (add-hook 'compilation-start-hook 'rspec-run-before-verification-hooks nil t)
   (add-hook 'compilation-filter-hook 'rspec-colorize-compilation-buffer nil t)
   (add-hook 'compilation-finish-functions 'rspec-store-failures nil t)
   (add-hook 'compilation-finish-functions 'rspec-handle-error nil t)

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -907,7 +907,6 @@ or a cons (FILE . LINE), to run one example."
         (insert-text-button url 'type 'help-url 'help-args (list url))
         (insert ".\n")))))
 
-
 (defun rspec-run-after-verification-hooks (&rest ignore)
   "Executes any functions in `rspec-after-verification-hook'"
   (run-hooks 'rspec-after-verification-hook))
@@ -920,7 +919,6 @@ or a cons (FILE . LINE), to run one example."
   (or (file-exists-p (expand-file-name "Rakefile" directory))
       (file-exists-p (expand-file-name "Gemfile" directory))
       (file-exists-p (expand-file-name "Berksfile" directory))))
-
 
 (defun rspec-project-root (&optional directory)
   "Finds the root directory of the project by walking the directory tree until it finds a rake file."

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -51,6 +51,8 @@
 ;;
 ;;; Change Log:
 ;;
+;; 1.17 - Add `rspec-before-verification-hook' and `rspec-after-verification-hook'
+;;        hooks
 ;; 1.16 - Add `rspec-yank-last-command' function (Sergiy Kukunin)
 ;; 1.15 - Add option to run spec commands in a Docker container
 ;;        through "docker exec".


### PR DESCRIPTION
Fork of #152

This branch contains a little of edits for comments in the PR.
And here is an answer to the question in the PR:

> Are you sure the last argument here should be nil?

In my survey, it does not need to make globally `add-hook`. So I just make it locally.

If I `add-hook` globally even once, I need to `remove-hook` explicitly to make it locally. Just make locally `add-hook` without `remove-hook` in the situation, functions in `rspec-before-verification-hook` will be called twice. In my guess, it may be that the developer merely misunderstood it :)