### PR TITLE
Fix rspec-run-last-failed, rspec-verify-continue, rspec-verify-matching

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -4,7 +4,7 @@
 ;; Author: Peter Williams, et al.
 ;; URL: http://github.com/pezra/rspec-mode
 ;; Created: 2011
-;; Version: 1.19
+;; Version: 1.20
 ;; Keywords: rspec ruby
 ;; Package-Requires: ((ruby-mode "1.0") (cl-lib "0.4"))
 
@@ -51,6 +51,7 @@
 ;;
 ;;; Change Log:
 ;;
+;; 1.20 - Fix a regression of `rspec-run-last-failed'
 ;; 1.19 - Fix bugs about change of buffer naming
 ;; 1.18 - Add `rspec-before-verification-hook' and `rspec-after-verification-hook'
 ;;        hooks
@@ -833,15 +834,12 @@ or a cons (FILE . LINE), to run one example."
       target
     (make-rspec-compile-target
      :use-rake (rspec-rake-p)
-     :specs (let ((entries (cond ((and (listp target) (listp (cdr target)))
-                                  (mapcar (lambda (f) (list f)) target))
-                                 ((listp target)
-                                  (list target))
-                                 (t
-                                  (list (list target))))))
-              (mapcar (lambda (e)
-                        (cons (expand-file-name (car e)) (cdr e)))
-                      entries)))))
+     :specs (cond ((and (listp target) (listp (cdr target)))
+                   (mapcar (lambda (f) (list f)) target))
+                  ((listp target)
+                   (list target))
+                  (t
+                   (list (list target)))))))
 
 (defun rspec-compile-command (target &optional opts)
   "Composes RSpec command line for the compile function"


### PR DESCRIPTION
`rspec-run-last-failed`, `rspec-verify-continue` and `rspec-verify-matching` fail because they run with wrong path.

Here is an output example:

```
bundle exec rspec --options /home/kzkn/.ghq/github.com/kzkn/proj/.rspec /home/kzkn/.ghq/github.com/kzkn/proj/spec/models/spec/models/foo_spec.rb\:43

An error occurred while loading ./spec/models/spec/models/foo_spec.rb.
Failure/Error: load file

LoadError:
  cannot load such file -- /home/kzkn/.ghq/github.com/kzkn/proj/spec/models/spec/models/foo_spec.rb
```

Unnecessary `expand-file-name` causes this problem.

https://github.com/pezra/rspec-mode/blob/58b741c1a7ecf3b190d89a56c32c0fa5d44700f2/rspec-mode.el#L843

It was added on developing #170 by me. Removing the `expand-file-name` solves this problem.
Sorry for enbug :(