### PR TITLE
Mark "docker run" & "docker exec" as safe

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -161,7 +161,7 @@
   :type 'string
   :group 'rspec-mode
   :safe (lambda (value)
-          (member value '("docker-compose run" "docker-compose exec"))))
+          (member value '("docker-compose run" "docker-compose exec" "docker run" "docker exec"))))
 
 (defcustom rspec-docker-container "rspec-container-name"
   "Name of the docker container to run rspec in."


### PR DESCRIPTION
If `docker-compose run` is safe, `docker run` is safe... right?

(I could be convinced otherwise.   `docker-compose run evil stuff` requires that you first have a service named `evil`  in your docker-compose.yml file, whereas `docker run evil stuff` will attempt to download the `evil` image from dockerhub.  That said, if you're looking at 3rd-party code with an evil .dir-locals.el file, presumably there's nothing stopping that 3rd party code from also having an evil docker-compose.yml file, so this doesn't seem to open up any interesting new attacks)