### PR TITLE
Fix target directory bug

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -818,9 +818,9 @@ or a cons (FILE . LINE), to run one example."
     (if rspec-use-chruby
         (chruby-use-corresponding))
 
-    (let ((default-directory (or (rspec-project-root) default-directory))
+    (let ((target-directory (or (rspec-project-root) default-directory))
           (compilation-buffer-name-function 'rspec-compilation-buffer-name))
-      (setf (rspec-compile-target-directory compile-target) default-directory)
+      (setf (rspec-compile-target-directory compile-target) target-directory)
       (compile
        (rspec-compile-command compile-target opts)
        'rspec-compilation-mode))))


### PR DESCRIPTION
# Problem

Running `rspec-verify-continue` appends the current directory to the relative directory of the file it is run from

# Reproduce

Open spec/models/foo_spec.rb
    M-x rspec-verify-continue

It will try to run rspec **/user/me/project/spec/models/**spec/models/foo_spec.rb

# Cause and solution

dynamic scoping and closure not playing well, avoid shadowing of variables to resolve