### PR TITLE
Add: variable to set a custom unit spec directory path

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,19 @@ option. To turn this on:
 (setq rspec-allow-multiple-compilation-buffers t)
 ```
 
+### Setting a Custom Spec Directory
+
+If the spec directory layout doesn't follow usual conventions or is in an unusual
+location, you can set the location of the specs relative to your project root with:
+
+```elisp
+(setq rspec-unit-test-dir "relative_path/to_my_specs")
+```
+
+For example, project ruby files are in `lib/` but the specs are in `spec/unit_tests/lib`
+for some reason.  Set the `rspec-unit-test-dir` variable to "spec/unit_tests" and the
+rspec-mode toggling should work as expected.
+
 ## Contributing
 
 Love RSpec and Emacs? Great, help out by contributing. The easiest way

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -4,7 +4,7 @@
 ;; Author: Peter Williams, et al.
 ;; URL: http://github.com/pezra/rspec-mode
 ;; Created: 2011
-;; Version: 1.20
+;; Version: 1.21
 ;; Keywords: rspec ruby
 ;; Package-Requires: ((ruby-mode "1.0") (cl-lib "0.4"))
 
@@ -51,6 +51,7 @@
 ;;
 ;;; Change Log:
 ;;
+;; 1.21 - Allow spec directory to be customized (`rspec-unit-test-dir')
 ;; 1.20 - Fix a regression of `rspec-run-last-failed'
 ;; 1.19 - Fix bugs about change of buffer naming
 ;; 1.18 - Add `rspec-before-verification-hook' and `rspec-after-verification-hook'

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -255,6 +255,13 @@ for spec files corresponding to files inside them."
   :safe 'listp
   :group 'rspec-mode)
 
+(defcustom rspec-unit-test-dir nil
+  "If non-nil, look for spec files in this directory instead of
+the default project root spec/ directory"
+  :type 'string
+  :group 'rspec-mode
+  )
+
 (defcustom rspec-autosave-buffer nil
   "If t save the current buffer when running
 `rspec-verify', `rspec-verify-single', `rspec-verify-matching',
@@ -546,7 +553,9 @@ to navigate to the example or method corresponding to point."
                            "^\\.\\./"))
           (relative-file-name (file-relative-name a-file-name (rspec-spec-directory a-file-name))))
       (rspec-specize-file-name (expand-file-name (replace-regexp-in-string replace-regex "" relative-file-name)
-                                                 (rspec-spec-directory a-file-name))))))
+                                                 (if rspec-unit-test-dir
+                                                     (concat (rspec-project-root) "/" rspec-unit-test-dir "/")
+                                                   (rspec-spec-directory a-file-name)))))))
 
 (defun rspec-target-in-holder-dir-p (a-file-name)
   (string-match (concat "^" (concat
@@ -564,7 +573,9 @@ to navigate to the example or method corresponding to point."
            for filename = (cl-loop for dir in (cons "."
                                                     rspec-primary-source-dirs)
                                    for target = (replace-regexp-in-string
-                                                 "/spec/"
+                                                 (if rspec-unit-test-dir
+                                                     rspec-unit-test-dir
+                                                   "/spec/")
                                                  (concat "/" dir "/")
                                                  candidate)
                                    if (file-exists-p target)


### PR DESCRIPTION
Created issue #184 to reference this outside of the other one.

I've tested this out with my situation and it seems to work, though I don't have extensive testing around it to see if it will effect normal use.  I'm happy to keep working on it if you see any issues with this solution.