### PR TITLE
Allows customization of the docker wrapper function

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -174,8 +174,7 @@
   :type 'string
   :group 'rspec-mode)
 
-(defcustom rspec-docker-wrapper-fn
-  (lambda (rspec-docker-command rspec-docker-container command) (format "%s %s sh -c \"%s\"" rspec-docker-command rspec-docker-container command))
+(defcustom rspec-docker-wrapper-fn 'rspec--docker-default-wrapper
   "Function for wrapping a command for execution inside a dockerized environment. "
   :type 'function
   :group 'rspec-mode)
@@ -719,6 +718,10 @@ file if it exists, or sensible defaults otherwise."
       (vagrant (replace-regexp-in-string (regexp-quote (rspec-project-root))
                                          rspec-vagrant-cwd file))
       (t  file)))))
+
+(defun rspec--docker-default-wrapper (rspec-docker-command rspec-docker-container command)
+  "Function for wrapping a command for execution inside a dockerized environment. "
+  (format "%s %s sh -c \"%s\"" rspec-docker-command rspec-docker-container command))
 
 (defun rspec--docker-wrapper (command)
   (if (rspec-docker-p)

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -174,6 +174,12 @@
   :type 'string
   :group 'rspec-mode)
 
+(defcustom rspec-docker-wrapper-fn
+  (lambda (rspec-docker-command rspec-docker-container command) (format "%s %s sh -c \"%s\"" rspec-docker-command rspec-docker-container command))
+  "Function for wrapping a command for execution inside a dockerized environment. "
+  :type 'function
+  :group 'rspec-mode)
+
 (defcustom rspec-vagrant-cwd "/vagrant/"
   "Working directory when running inside Vagrant. Use trailing slash."
   :type 'string
@@ -716,10 +722,10 @@ file if it exists, or sensible defaults otherwise."
 
 (defun rspec--docker-wrapper (command)
   (if (rspec-docker-p)
-      (format "%s %s sh -c \"%s\""
-              rspec-docker-command
-              rspec-docker-container
-              command)
+      (funcall rspec-docker-wrapper-fn
+               rspec-docker-command
+               rspec-docker-container
+               command)
     command))
 
 (defun rspec--vagrant-wrapper (command)


### PR DESCRIPTION
This PR was inspired by my need to add a `xvfb-run` before the `bundle exec` in the docker container. 

I figured it'd be a more flexible way for other use cases too (e.g. when `sh` is not in the image for some reason, but another shell is), so here it is.