### PR TITLE
Make as a hyperlink the screenshot path automatically taken by System Spec

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -891,8 +891,7 @@ or a cons (FILE . LINE), to run one example."
 
 (defvar rspec-compilation-error-regexp-alist-alist
   '((rspec-capybara-html "^ +HTML screenshot: \\([0-9A-Za-z@_./\:-]+\\.html\\)" 1 nil nil 0 1)
-    (rspec-capybara-screenshot "^ +Image screenshot: \\([0-9A-Za-z@_./\:-]+\\.png\\)" 1 nil nil 0 1)
-    (rspec-system-spec-screenshot "^ +\\[Screenshot\\]: \\(.+\\.png\\)" 1 nil nil 0 1)
+    (rspec-capybara-screenshot "\\(Image \\)?\\[?[sS]creenshot\\]?: \\(.+\\.png\\)" 2 nil nil 0 2)
     (rspec "^ +# \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\):in" 1 2 nil 2 1)
     (rspec-pendings "^ +# \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 1 1)
     (rspec-summary "^rspec \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 2 1)))

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -892,6 +892,7 @@ or a cons (FILE . LINE), to run one example."
 (defvar rspec-compilation-error-regexp-alist-alist
   '((rspec-capybara-html "^ +HTML screenshot: \\([0-9A-Za-z@_./\:-]+\\.html\\)" 1 nil nil 0 1)
     (rspec-capybara-screenshot "^ +Image screenshot: \\([0-9A-Za-z@_./\:-]+\\.png\\)" 1 nil nil 0 1)
+    (rspec-system-spec-screenshot "^ +\\[Screenshot\\]: \\(.+\\.png\\)" 1 nil nil 0 1)
     (rspec "^ +# \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\):in" 1 2 nil 2 1)
     (rspec-pendings "^ +# \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 1 1)
     (rspec-summary "^rspec \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 2 1)))

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -891,7 +891,7 @@ or a cons (FILE . LINE), to run one example."
 
 (defvar rspec-compilation-error-regexp-alist-alist
   '((rspec-capybara-html "^ +HTML screenshot: \\([0-9A-Za-z@_./\:-]+\\.html\\)" 1 nil nil 0 1)
-    (rspec-capybara-screenshot "^ +\\(\\|Image \\)\\[?[sS]creenshot\\]?: \\(.+\\.png\\)" 2 nil nil 0 2)
+    (rspec-capybara-screenshot "^ +\\(Image \\)?\\[?[sS]creenshot\\]?: \\(.+\\.png\\)" 2 nil nil 0 2)
     (rspec "^ +# \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\):in" 1 2 nil 2 1)
     (rspec-pendings "^ +# \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 1 1)
     (rspec-summary "^rspec \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 2 1)))

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -891,7 +891,7 @@ or a cons (FILE . LINE), to run one example."
 
 (defvar rspec-compilation-error-regexp-alist-alist
   '((rspec-capybara-html "^ +HTML screenshot: \\([0-9A-Za-z@_./\:-]+\\.html\\)" 1 nil nil 0 1)
-    (rspec-capybara-screenshot "\\(Image \\)?\\[?[sS]creenshot\\]?: \\(.+\\.png\\)" 2 nil nil 0 2)
+    (rspec-capybara-screenshot "^ +\\(\\|Image \\)\\[?[sS]creenshot\\]?: \\(.+\\.png\\)" 2 nil nil 0 2)
     (rspec "^ +# \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\):in" 1 2 nil 2 1)
     (rspec-pendings "^ +# \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 1 1)
     (rspec-summary "^rspec \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 2 1)))


### PR DESCRIPTION
Make as a hyperlink the screenshot path automatically taken by RSpec's System Spec.

Example:

```ruby
RSpec.describe "テスト", type: :system, js: true do
  it "内容が表示されること" do
    # this will be fail, system spec will take a screenshot automatically.
    expect(page).to have_content "ハロー"
  end
end
```

Outputs:

```
  1) テスト 内容が表示されること
     Failure/Error: expect(page).to have_content "ハロー"
       expected to find text "ハロー" in ""
     
     [Screenshot]: /home/kazuki/myproj/tmp/screenshots/failures_r_spec_example_groups_nested_2_内容が表示されること_237.png
```

This pull request makes the above path as a hyperlink.