### PR TITLE
Check files are not directories for Gemfile, Rakefile, Berksfile

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -952,14 +952,10 @@ or a cons (FILE . LINE), to run one example."
   "Executes any functions in `rspec-before-verification-hook'"
   (run-hooks 'rspec-before-verification-hook))
 
-(defun file-exists-and-is-not-directory-p (file)
-  (and (file-exists-p file)
-       (not (file-directory-p file))))
-
 (defun rspec-project-root-directory-p (directory)
-  (or (file-exists-and-is-not-directory-p (expand-file-name "Rakefile" directory))
-      (file-exists-and-is-not-directory-p (expand-file-name "Gemfile" directory))
-      (file-exists-and-is-not-directory-p (expand-file-name "Berksfile" directory))))
+  (or (file-regular-p (expand-file-name "Rakefile" directory))
+      (file-regular-p (expand-file-name "Gemfile" directory))
+      (file-regular-p (expand-file-name "Berksfile" directory))))
 
 (defun rspec-project-root (&optional directory)
   "Find the root directory of the project.

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -945,10 +945,14 @@ or a cons (FILE . LINE), to run one example."
   "Executes any functions in `rspec-before-verification-hook'"
   (run-hooks 'rspec-before-verification-hook))
 
+(defun file-exists-and-is-not-directory-p (file)
+  (and (file-exists-p file)
+       (not (file-directory-p file))))
+
 (defun rspec-project-root-directory-p (directory)
-  (or (file-exists-p (expand-file-name "Rakefile" directory))
-      (file-exists-p (expand-file-name "Gemfile" directory))
-      (file-exists-p (expand-file-name "Berksfile" directory))))
+  (or (file-exists-and-is-not-directory-p (expand-file-name "Rakefile" directory))
+      (file-exists-and-is-not-directory-p (expand-file-name "Gemfile" directory))
+      (file-exists-and-is-not-directory-p (expand-file-name "Berksfile" directory))))
 
 (defun rspec-project-root (&optional directory)
   "Finds the root directory of the project by walking the directory tree until it finds a rake file."


### PR DESCRIPTION
I think this is a rare case but I ran into an issue at $WORK where there is a `Gemfile` directory in the `spec` folder. I don't think that `Gemfile`s, `Rakefile`s and `Berksfile`s can be directories.

This PR attempts to only look for files with the above names rather than both files and directories.