### PR TITLE
Resolve remaining byte compilation warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,15 @@
 EMACS ?= emacs
 
+EL_FILES := \
+	rspec-mode.el \
+	test/rspec-mode-test.el
+ELC_FILES := $(EL_FILES:.el=.elc)
+
 .PHONY: elpa clean test
 
-test:
+.SUFFIXES: .el .elc
+
+test: $(ELC_FILES)
 	${EMACS} -Q --batch -l ert --directory . -l test/rspec-mode-test.el \
 	         --eval '(ert-run-tests-batch-and-exit)'
 
@@ -18,3 +25,6 @@ elpa: *.el
 
 clean:
 	@rm -rf rspec-mode-*/ rspec-mode-*.tar *.elc
+
+.el.elc:
+	${EMACS} -Q --batch -L . --eval '(setq byte-compile-error-on-warn t)' -f batch-byte-compile $<

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -316,6 +316,7 @@ buffers concurrently"
       (progn
         (rspec-set-imenu-generic-expression)
         (when (boundp 'yas-extra-modes)
+          (declare-function yas--load-pending-jits ())
           (if (fboundp 'yas-activate-extra-mode)
               ;; Yasnippet 0.8.1+
               (yas-activate-extra-mode 'rspec-mode)
@@ -362,6 +363,7 @@ buffers concurrently"
 (defun rspec-install-snippets ()
   "Add `rspec-snippets-dir' to `yas-snippet-dirs' and load snippets from it."
   (require 'yasnippet)
+  (declare-function yas-load-directory (top-level-dir &optional use-jit interactive))
   (defvar yas-snippet-dirs)
   (add-to-list 'yas-snippet-dirs rspec-snippets-dir t)
   (yas-load-directory rspec-snippets-dir))


### PR DESCRIPTION
Fixes the following warnings:

    rspec-mode.el:367:4: Warning: the function ‘yas-load-directory’ is not known
        to be defined.
    rspec-mode.el:324:14: Warning: the function ‘yas--load-pending-jits’ is not
        known to be defined.

The elisp files are now compiled during CI and will error on a warning.
This ensures the files remain warning free.