### PR TITLE
Add support for emacs 29 and `ruby-ts-mode`

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -1107,7 +1107,7 @@ Looks at FactoryGirl::Syntax::Methods usage in spec_helper."
 
 ;; Hook up all Ruby buffers.
 ;;;###autoload
-(dolist (hook '(ruby-mode-hook ruby-ts-mode enh-ruby-mode-hook))
+(dolist (hook '(ruby-mode-hook ruby-ts-mode-hook enh-ruby-mode-hook))
   (add-hook hook 'rspec-enable-appropriate-mode))
 
 ;; Add verify related spec keybinding to rails minor mode buffers

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -1107,7 +1107,7 @@ Looks at FactoryGirl::Syntax::Methods usage in spec_helper."
 
 ;; Hook up all Ruby buffers.
 ;;;###autoload
-(dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
+(dolist (hook '(ruby-mode-hook ruby-ts-mode enh-ruby-mode-hook))
   (add-hook hook 'rspec-enable-appropriate-mode))
 
 ;; Add verify related spec keybinding to rails minor mode buffers


### PR DESCRIPTION
With Emacs 29 around the corner, it adds a new ruby mode, `ruby-ts-mode`, that has its own set of hooks and configurations. This PR looks to add `ruby-ts-mode` to the list of hooks rspec adds itself too.