### PR TITLE
When executing via docker, execute in the context of the docker file

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: dgutov

--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -127,6 +127,21 @@
 (define-key rspec-dired-mode-keymap (kbd "a") 'rspec-verify-all)
 (define-key rspec-dired-mode-keymap (kbd "r") 'rspec-rerun)
 
+(defvar rspec--docker-commands
+  '("docker exec"
+    "docker run"
+    "docker-compose exec"
+    "docker-compose run"
+    "nerdctl compose exec"
+    "nerdctl compose run"
+    "nerdctl exec"
+    "nerdctl run"
+    "podman exec"
+    "podman run"
+    "podman-compose exec"
+    "podman-compose run")
+  "List of acceptable docker commands to use.")
+
 (defgroup rspec-mode nil
   "RSpec minor mode."
   :group 'languages)
@@ -163,7 +178,7 @@
   :type 'string
   :group 'rspec-mode
   :safe (lambda (value)
-          (member value '("docker-compose run" "docker-compose exec" "docker run" "docker exec"))))
+          (member value rspec--docker-commands)))
 
 (defcustom rspec-docker-container "rspec-container-name"
   "Name of the docker container to run rspec in."


### PR DESCRIPTION
Hi there,

This PR modifies rspec mode's docker wrapper, ensuring that the docker command execution happens in the same directory as the docker file (or docker-compose file).

This allows me to run rspec using a docker-compose file which is outside of the ruby project root, and by having `default-directory` set to my ruby project root means that relative filepaths in stacktraces map correctly.