### PR TITLE
Reprioritise project-relative paths

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -766,12 +766,12 @@ file if it exists, or sensible defaults otherwise."
         (vagrant (rspec-vagrant-p)))
     (shell-quote-argument
      (cond
+      (rspec-use-relative-path (file-relative-name file (rspec-project-root)))
       (remote (substring file (length remote)))
       (docker (replace-regexp-in-string (regexp-quote (rspec-project-root))
                                          rspec-docker-cwd file))
       (vagrant (replace-regexp-in-string (regexp-quote (rspec-project-root))
                                          rspec-vagrant-cwd file))
-      (rspec-use-relative-path (file-relative-name file (rspec-project-root)))
       (t  file)))))
 
 (defun rspec--docker-default-wrapper (docker-command docker-container command)


### PR DESCRIPTION
Currently, `rspec-use-relative-path` is not respected for remote/container/vagrant files.

This change ensures that relative paths are passed through to RSpec, even if the target is remote:

```
-*- mode: rspec-compilation; default-directory: "/sshx:john@dest:~/code/work/rails/" -*-
RSpec Compilation started at Thu Aug 17 19:26:52

podman-compose -f ../dev/docker-compose.yml exec rails sh -c "bundle exec rake spec SPEC_OPTS='--options .rspec' SPEC='spec/'"
```