### PR TITLE
Match output from current actionpack for screenshot image

### DIFF
--- a/rspec-mode.el
+++ b/rspec-mode.el
@@ -933,7 +933,7 @@ or a cons (FILE . LINE), to run one example."
 
 (defvar rspec-compilation-error-regexp-alist-alist
   '((rspec-capybara-html "^ +HTML screenshot: \\([0-9A-Za-z@_./\:-]+\\.html\\)" 1 nil nil 0 1)
-    (rspec-capybara-screenshot "^ +\\(Image \\)?\\[?[sS]creenshot\\]?: \\(.+\\.png\\)" 2 nil nil 0 2)
+    (rspec-capybara-screenshot "^ +\\(Image \\)?\\[?[sS]creenshot\\( Image\\)?\\]?: \\(.+\\.png\\)" 3 nil nil 0 3)
     (rspec "^ +# \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\):in" 1 2 nil 2 1)
     (rspec-pendings "^ +# \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 1 1)
     (rspec-summary "^rspec \\([0-9A-Za-z@_./:-]+\\.rb\\):\\([0-9]+\\)" 1 2 nil 2 1)))

--- a/test/rspec-mode-test.el
+++ b/test/rspec-mode-test.el
@@ -29,3 +29,9 @@
     (should-not (rspec--test-compilation-match-p example 'error))
     (should-not (rspec--test-compilation-match-p example 'info))
     (should (rspec--test-compilation-match-p example 'warning))))
+
+(ert-deftest rspec--test-screenshot ()
+  "matches screenshot"
+  (should (rspec--test-compilation-match-p "     [Screenshot Image]: ./capybara/some_file_123.png" 'info))
+  (should (rspec--test-compilation-match-p "     [Screenshot]: ./capybara/some_file_123.png" 'info))
+  (should (rspec--test-compilation-match-p "     Image Screenshot: ./capybara/some_file_123.png" 'info)))


### PR DESCRIPTION
Actionpack outputs a line like this when it saved a screenshot:

```
     [Screenshot Image]: /path/to/tmp/capybara/failures_r_spec_example_groups_example_749.png
```
Previously, output like the above was not automatically converted to a link.

(from https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb#L135)